### PR TITLE
extend coverage report to readonly users

### DIFF
--- a/scrc/preprocessors/abstract_preprocessor.py
+++ b/scrc/preprocessors/abstract_preprocessor.py
@@ -8,6 +8,7 @@ from collections import Counter, Sized
 from pathlib import Path
 import glob
 from time import sleep
+from typing import Optional
 
 import spacy
 from spacy.lang.de import German
@@ -173,19 +174,22 @@ class AbstractPreprocessor:
                 yield chunk_df
 
     @staticmethod
-    def update(engine, df: pd.DataFrame, table: str, columns: list, output_dir: Path):
+    def update(engine, df: pd.DataFrame, table: str, columns: list, output_dir: Path, filename: Optional[str] = None):
         """
         Updates the given columns in a table with the data provided by the df
         :param engine:              the db engine to work upon
         :param df:                  the df providing the data for the update
         :param table:               the table to be updated
         :param columns:             the columns to be updated
+        :param output_dir:          the output directory if output stored as files instead of the database (readonly users)
+        :param filename:            the filename to be used for the output (if stored as files)
         :return:
         """
 
         if not AbstractPreprocessor._check_write_privilege(engine):
-            AbstractPreprocessor.create_dir(output_dir, os.getlogin())
-            path = Path.joinpath(output_dir, os.getlogin(), datetime.now().isoformat() + '.json')
+            assert filename is not None, 'filename must be provided if the user does not have write privileges'
+            output_dir.mkdir(parents=True, exist_ok=True) 
+            path = Path.joinpath(output_dir, filename)
             with path.open("a") as f:
                 df.to_json(f)
             return

--- a/scrc/preprocessors/abstract_preprocessor.py
+++ b/scrc/preprocessors/abstract_preprocessor.py
@@ -187,9 +187,13 @@ class AbstractPreprocessor:
         """
 
         if not AbstractPreprocessor._check_write_privilege(engine):
-            assert filename is not None, 'filename must be provided if the user does not have write privileges'
-            output_dir.mkdir(parents=True, exist_ok=True) 
-            path = Path.joinpath(output_dir, filename)
+            path = ''
+            if filename is None:
+                AbstractPreprocessor.create_dir(output_dir, os.getlogin())
+                path = Path.joinpath(output_dir, os.getlogin(), datetime.now().isoformat() + '.json')
+            else:
+                output_dir.mkdir(parents=True, exist_ok=True)
+                path = Path.joinpath(output_dir, filename)
             with path.open("a") as f:
                 df.to_json(f)
             return

--- a/scrc/preprocessors/extractors/section_splitter.py
+++ b/scrc/preprocessors/extractors/section_splitter.py
@@ -92,7 +92,7 @@ class SectionSplitter(AbstractExtractor):
             return
 
         total_processed = self.total_to_process
-        # ceil divivsion to get the number of files (chunks) that should be present if pipeline finished
+        # ceil division to get the number of files (chunks) that should be present if pipeline finished
         total_chunks = -(self.total_to_process // - self.chunksize)
         # if the pipeline was interrupted, notify the user, this allows to print coverage half way through
         # with the coverage for the parsed chunks still being valid

--- a/scrc/preprocessors/extractors/section_splitter.py
+++ b/scrc/preprocessors/extractors/section_splitter.py
@@ -121,7 +121,6 @@ class SectionSplitter(AbstractExtractor):
             batchinfo = {'uuid': uuid.uuid4().hex[:8], 'chunknumber': 0}
             log_dir = Path.joinpath(self.output_dir, os.getlogin(), spider, lang, batchinfo['uuid'])
             for df in dfs:
-                import pdb; pdb.set_trace()
                 df = df.apply(self.process_one_df_row, axis='columns')
                 filename = f"{batchinfo['chunknumber']}.json"
                 self.update(engine, df, lang, [section.value for section in Section] + ['paragraphs'], log_dir, filename)


### PR DESCRIPTION
### What & Why
The coverage report at the end of parsing is not shown for users who have readonly access to the database. This PR ensures logs are written in distinguishable format and a coverage report can be retrieved even without database access.
Furthermore the report can also be retrieved at breakpoints, allowing to check coverage without running the full spider. In that case the report only considers files that have been parsed so far, giving the correct % of detected sections. This process can be repeated at several breakpoints, the coverage will be updated dynamically.

### Examples
Run any spider as `readonly` user *OR* set a breakpoint in the context `section_splitter:process_one_spider:<any df>` and call `self.log_coverage_from_json(engine, spider, lang, batchinfo)` with the parameters already set in the context.
###### Coverage report after parsing
![image](https://user-images.githubusercontent.com/26817152/144656188-ec984b03-d9a8-4a91-ad13-80dc94347258.png)

###### Coverage report at breakpoints
![image](https://user-images.githubusercontent.com/26817152/144656248-cd4e75f7-e6b0-40e2-9d54-14255ecbdff8.png)

### Remarks
- I will add some info on the debug_utils (https://github.com/JoelNiklaus/SwissCourtRulingCorpus/pull/17#issue-1067106120) to allow new users to use this feature as well for debugging / benchmarking their parsers if both PRs are accepted.
- The report is **only implemented for the section splitting**. Other tasks still rely on the standard coverage report. If this PR is helpful I will probably extend it to the other extractors.
- I'm not very well versed with pipeline architectures, so feedback on better structure and parameters is much appreciated 😄 

### Review & Testing
- I could not test the functionality for users with write-priviledge (for obvious reasons..), so it would be nice if you could quickly check with a smaller spider with a write-priviledged user.