### PR TITLE
Section splitting be bvd

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jupyter notebook --no-browser --port=8888 --notebook-dir=scrc/notebooks
 ### Forward port to local machine (run on local machine)
 
 ```bash
-ssh -N -f -L localhost:8888:localhost:8888 fdn-admin@fdn-sandbox3.inf.unibe.ch
+ssh -N -f -L localhost:8888:localhost:8888 <your-username>@fdn-sandbox3.inf.unibe.ch
 ```
 
 ## Postgres

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jupyter notebook --no-browser --port=8888 --notebook-dir=scrc/notebooks
 ### Forward port to local machine (run on local machine)
 
 ```bash
-ssh -N -f -L localhost:8888:localhost:8888 <your-username>@fdn-sandbox3.inf.unibe.ch
+ssh -N -f -L localhost:8888:localhost:8888 fdn-admin@fdn-sandbox3.inf.unibe.ch
 ```
 
 ## Postgres

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -574,8 +574,8 @@ def BE_BVD(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional
 
     # split sections by given regex, compile regex to cache them
     regexes = {
-        Language.DE: re.compile(r'(.*?)(Sachverhalt.*)(Erwägungen.*)(Entscheid.*)(Eröffnung.*)', re.DOTALL),
-        Language.FR: re.compile(r'(.*?)(Faits.*)(Considérants.*)(Décision.*)(Notification.*)', re.DOTALL)
+        Language.DE: re.compile(r'(.*?)(Sachverhalt(?:\n  \n|\n\n|\n \n| \n\n).*?)(Erwägungen(?: \n\n|\n\n).*?)(Entscheid(?:\n\n| \n\n1).*?)((Eröffnung(?:\n\n|\n-)|[Zz]u eröffnen:).*)', re.DOTALL),
+        Language.FR: re.compile(r'(.*?)(Faits\n\n.*?)(Considérants\n\n.*?)(Décision\n\n.*?)(Notification\n\n|A notifier:\n.*)', re.DOTALL)
     }
 
     try:
@@ -587,6 +587,10 @@ def BE_BVD(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional
     match = re.search(regex, decision)
 
     if match is None:
+        # TODO if sachverhalt and erwägungen are in the same section, add them to a single section
+        if re.search('Sachverhalt und Erwägungen\n', decision, re.M):
+            print("concated sections, not yet handled")
+        
         return None
     
     # split paragraphs

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -595,9 +595,18 @@ def BE_BVD(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional
     
     # split paragraphs
     sections = {}
-    for section, section_name in zip(list(Section), match.groups()):
-        sections[section] = section_name.split('\n\n')
-        # remove empty strings happening when two empty lines follow each other
-        sections[section] = list(filter(lambda x: x != '', sections[section]))
+    for section, section_text in zip(list(Section), match.groups()):
 
+        split = re.split('(\\n\d\. \w+\\n)', section_text)
+        # paragraphs are now split into title, paragraph header (e.g. '\n1. '), paragraph text
+        title = split[0]
+        # join header and text pairs back together (1+2, 3+4, 5+6, ...) if we found multiple (>2) paragraphs
+        paired = []
+        if len(split) > 2:
+            paired = [split[i] + split[i+1] for i in range(1, len(split) -1, 2)]
+        else:
+            paired = list(''.join(split[1:]))
+
+        sections[section] = [title] + paired
+    
     return sections


### PR DESCRIPTION
### Accuracy
Only misses a single [decision](https://www.bvd-entscheide.apps.be.ch/tribunapublikation/tribunavtplus/ServletDownload/120_2009_12_5ddb385fa6494ba4b07719b4d67e5ac4.pdf?path=2158c5b82986fcdf66411aa2b35a5fbfa9bd4cad399fc778a29bc6db09252a92144ef372f0c19d94924f63dfbb9b065b70de0c98a231c33cff348ef7ffcc9e7fc7e5823c5f56d15b5ccea900c4ed31a27112b23a39ba43d65720f3addd472759&pathIsEncrypted=1&dossiernummer=120_2009_12) which is very pooly formatted.

Accuracy is technically 99.91%, but I can't say much for the quality. Might look into it again when debugging tools are merged or with some info from issue https://github.com/JoelNiklaus/SwissCourtRulingCorpus/issues/20.

### Code quality
As it was the first spider with pdf's as input (i think?) I just came up with what i felt might be suited for this spider without too much concern about reusability. At least the regex is a one-pass matcher 😉 

 