### PR TITLE
Judgment extracting

### DIFF
--- a/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
@@ -207,57 +207,6 @@ def UR_Gerichte(rulings: str, namespace: dict) -> Optional[List[Judgment]]:
         raise ValueError(f"Found no judgment for the rulings {namespace['date']}. Please check!")
 
     return judgments
-  
-
-def UR_Gerichte(rulings: str, namespace: dict) -> Optional[List[Judgment]]:
-    """
-    Extract judgment outcomes from the rulings
-    :param rulings:     the string containing the rulings
-    :param namespace:   the namespace containing some metadata of the court decision
-    :return:            the list of judgments
-    """
-    
-    # Rather than extend and update the global markers, for this spider, specific markers are defined.
-    all_judgment_markers = {
-        Language.DE: {
-            Judgment.APPROVAL: [r'Gutheissung der Beschwerde', r'Bejahung der Beschwerdelegimitation'],
-            Judgment.PARTIAL_APPROVAL: [r'Teilweise Gutheissung der Beschwerde'],
-            Judgment.DISMISSAL: [r'Abweisung der Beschwerde', 
-                                r'Der Anzeige wird keine Folge gegeben', 
-                                r'Verneinung der Beschwerdelegimitation', 
-                                r'Abweisung der Verwaltungsgerichtsbeschwerde', 
-                                r'Abweisung der [Vv]erwaltungsrechtlichen Klage',
-                                r'Abweisung des Gesuches um Wiederherstellung der Frist',
-                                r'In concreto Abweisung der Berufung der Dienstbarkeitsbelasteten'],
-            Judgment.WRITE_OFF: [r'Abschreibung der Beschwerde vom Geschäftsprotokoll ']
-        }
-    }
-
-    # In canton UR, de only
-    if namespace['language'] != Language.DE:
-        raise ValueError(f'This function is only implemented for {Language.DE} so far.')
-    
-    # find all judgments in the rulings
-    judgments = []
-    for lang in all_judgment_markers:
-        for judg in all_judgment_markers[lang]:
-            for reg in (all_judgment_markers[lang])[judg]:
-                matches = re.finditer(reg, rulings, re.MULTILINE)
-                for num, match in enumerate(matches, start=1):
-                    from_, to_, match_text  = match.start(), match.end(), match.group()
-                    judgments.append(judg)
-    
-    # validate
-    if len(judgments) > 1:
-        # TODO: using from_ and to_ position of judgment, check the following cases
-        #   1) a match is included in another --> discard the one included
-        #   2) two matches overlap --> problem, check 
-        #   3) no judgment found --> update the all_judgment_markers 
-        raise ValueError(f"Found several judgments for the rulings {namespace['date']} . Please check!")
-    if len(judgments) == 0:
-        raise ValueError(f"Found no judgment for the rulings {namespace['date']}. Please check!")
-
-    return judgments
     
 
 def CH_BGer(rulings: str, namespace: dict) -> Optional[List[Judgment]]:

--- a/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
@@ -185,16 +185,31 @@ def UR_Gerichte(rulings: str, namespace: dict) -> Optional[List[Judgment]]:
     # In canton UR, de only
     if namespace['language'] != Language.DE:
         raise ValueError(f'This function is only implemented for {Language.DE} so far.')
+
+    def getJudgments(text: str, judgment_markers, debug=False) -> Optional[List[Judgment]]:
+        """
+        Get the judgment outcomes based on a regex dictionary for a given section string.
+        :param text:               the text string of the section, usually Section.RULINGS
+        :param judgment_markers:   the regex dicttionary for the different judgment outcomes
+        :param debug:              if set to True, prints debug output to console
+        :return:                   the list of judgment outcomes
+        """
+        
+        judgments = []
+        for lang in judgment_markers:
+            for judg in judgment_markers[lang]:
+                for reg in (judgment_markers[lang])[judg]:
+                    matches = re.finditer(reg, text, re.MULTILINE)
+                    for num, match in enumerate(matches, start=1):
+                        from_, to_, match_text  = match.start(), match.end(), match.group()
+                        judgments.append(judg)
+                        if debug:
+                            print(f'{judg} ("{match.group()}") at {to_/len(text):.1%} of the section.')
+                        
+        return judgments
     
     # find all judgments in the rulings
-    judgments = []
-    for lang in all_judgment_markers:
-        for judg in all_judgment_markers[lang]:
-            for reg in (all_judgment_markers[lang])[judg]:
-                matches = re.finditer(reg, rulings, re.MULTILINE)
-                for num, match in enumerate(matches, start=1):
-                    from_, to_, match_text  = match.start(), match.end(), match.group()
-                    judgments.append(judg)
+    judgments = getJudgments(rulings, all_section_markers)
     
     # validate
     if len(judgments) > 1:

--- a/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
@@ -213,13 +213,11 @@ def UR_Gerichte(rulings: str, namespace: dict) -> Optional[List[Judgment]]:
     
     # validate
     if len(judgments) > 1:
-        # TODO: using from_ and to_ position of judgment, check the following cases
-        #   1) a match is included in another --> discard the one included
-        #   2) two matches overlap --> problem, check 
-        #   3) no judgment found --> update the all_judgment_markers 
-        raise ValueError(f"Found several judgments for the rulings {namespace['date']} . Please check!")
+        message = f"For the decision {namespace['html_url']} several rulings where found from the rulings: {rulings}"
+        raise ValueError(message)
     if len(judgments) == 0:
-        raise ValueError(f"Found no judgment for the rulings {namespace['date']}. Please check!")
+        message = f"For the decision {namespace['html_url']} no main ruling was found from the rulings: {rulings}"
+        raise ValueError(message)
 
     return judgments
     


### PR DESCRIPTION
The idea is to use the start and end position of the match, to then handle the different cases. In the actual code for  _CH_BGer_, overlaping matches are simply removed by two rules. As the regexes in all_judgment_markers can grow, this makes maintaining maybe hard in the future. Rather compare the position of the match and check whether matches overlap or not . E.g.

- _Gutheissung der Beschwerde_  and 
- _Teilweise Gutheissung der Beschwerde_


