### PR TITLE
Bs omni judgment extractor

### DIFF
--- a/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
@@ -201,21 +201,15 @@ def get_judgments(rulings: str, namespace: dict) -> set:
     
     judgment_markers = prepare_judgment_markers(all_judgment_markers, namespace)
     
-    one = 1
-    two = 2
+    pattern = rf"{1}\.(.+?)(?:{2}\.|$)"
+    romanPattern = rf"{int_to_roman(1)}\.(.+?)(?:{int_to_roman(2)}\.|$)"
     
-    pattern = rf"{one}\.(.+?)(?:{two}\.|$)"
-    romanPattern = rf"{int_to_roman(one)}\.(.+?)(?:{int_to_roman(two)}\.|$)"
-    
-    if re.search(pattern, rulings):
+    if (re.search(pattern, rulings) or re.search(romanPattern, rulings)):
         judgments = numbered_rulings(judgments, rulings, namespace, judgment_markers)
-    elif re.search(romanPattern, rulings):
-        judgments = numbered_rulings(judgments, rulings, namespace, judgment_markers)
+        if not judgments:
+            judgments = unnumbered_rulings(judgments, rulings, judgment_markers)  
     else:
-        judgments = unnumbered_rulings(judgments, rulings, judgment_markers)
-    # 11.Mai, 1141.50.- 
-    if not judgments:
-        judgments = unnumbered_rulings(judgments, rulings, judgment_markers)   
+        judgments = unnumbered_rulings(judgments, rulings, judgment_markers) 
     return judgments
 
 def unnumbered_rulings(judgments, rulings, judgment_markers):

--- a/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
@@ -210,21 +210,21 @@ def get_judgments(rulings: str, namespace: dict) -> set:
         judgments = unnumbered_rulings(judgments, rulings, judgment_markers,namespace) 
     return judgments
 
-def unnumbered_rulings(judgments: set, rulings: str, judgment_markers: Dict[Any, str], namespace: dict):
-    return iterate_Judgments(rulings, judgments, judgment_markers, False, namespace)
+def unnumbered_rulings(judgments: set, rulings: str, judgment_markers: dict, namespace: dict):
+    return iterate_Judgments(rulings, judgments, judgment_markers, False)
 
 def numbered_rulings(judgments: set, rulings: str, namespace: dict, judgment_markers: dict):
     n = 1
     while len(judgments) == 0:
         try:
             ruling = get_nth_ruling(rulings, namespace, n)
-            judgments = iterate_Judgments(ruling, judgments, judgment_markers, True, namespace)
+            judgments = iterate_Judgments(ruling, judgments, judgment_markers, True)
             n += 1
         except ValueError:
             break
     return judgments
 
-def iterate_Judgments(ruling: str, judgments: set, judgment_markers: dict, numberedRuling: bool, namespace) -> set:
+def iterate_Judgments(ruling: str, judgments: set, judgment_markers: dict, numberedRuling: bool) -> set:
     positions = [];
     for judgment in Judgment:
                 markers = judgment_markers[judgment]
@@ -286,7 +286,7 @@ def search_rulings(rulings: str, start: str, end: str):
 # def CH_BGE(rulings: str, namespace: dict) -> Optional[List[str]]:
 #    return CH_BGer(rulings, namespace)
 
-def prepare_judgment_markers(all_judgment_markers: dict(Language, Any), namespace: dict) -> dict(Any, str): 
+def prepare_judgment_markers(all_judgment_markers: dict, namespace: dict) -> dict: 
     judgment_markers = all_judgment_markers[namespace['language']]
         # combine multiple regex into one for each section due to performance reasons
     judgment_markers = dict(map(lambda kv: (kv[0], '|'.join(kv[1])), judgment_markers.items()))


### PR DESCRIPTION
BS_Omni unlike the already implemented extracting function CH_BGer does not use Numbers such as 1. ..... 2. .... to list the different decisions. (Hauptbegehren, Nebenbegehren etc). It is a plain text in which in the first or rarely the first _few_ sentences list the ultimate decision. 

I have adapted the functions to first check whether a ruling adheres to the numbered structure or not. If it adheres to the numbered structure we will use the already implemented function of CH_BGer. If it is unnumbered, we will search over the whole text to find matches. All matches positions will then be compared to extract the first instance. The first instance of a match is almost all the time the main decision (Hauptbegehren). 

This also increases the amount of judgments extracted for CH_BGer since there are some instances where the cases do not adhere to the numbered structure in which case it will execute the unnumbered strategy.

There are some instances in which it wrongly assumes a numbered structure such as `501.50.-`. If there is no judgment found, we will execute the unnumbered function.

- extracted useful functions to avoid code duplication
- extracted and renamed the original CH_BGer function to `numbered_rulings`
- implemented `unnumbered_rulings` function which iterates through the whole text
- implemented `getFirstInstance` which extracts the very first match

