### PR TITLE
Extend section splitting helpers

### DIFF
--- a/scrc/preprocessors/extractors/section_splitter.py
+++ b/scrc/preprocessors/extractors/section_splitter.py
@@ -85,7 +85,7 @@ class SectionSplitter(AbstractExtractor):
             df_chunk = pd.read_json(str(path / f"{chunk}.json"))
             summary['total_collected'] += df_chunk.shape[0]
             for section in Section:
-                summary[section.value] += df_chunk[section.value].count()
+                summary[section.value] += int((df_chunk[section.value] != '').sum())
 
         if summary['total_collected'] == 0:
             self.logger.info(f"Could not find any stored log files for batch {batch_info['uuid']} in {lang}")

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -7,6 +7,7 @@ import re
 from scrc.enums.language import Language
 from scrc.enums.section import Section
 from scrc.utils.main_utils import clean_text
+from scrc.utils.log_utils import get_logger
 
 """
 This file is used to extract sections from decisions sorted by spiders.
@@ -182,7 +183,7 @@ def associate_sections(paragraphs: List[str], section_markers, namespace: dict, 
         else:
             message = f"({namespace['id']}): We got stuck at section {current_section}. Please check! " \
                   f"Here is the date of the decision: {namespace['date']}"
-        raise ValueError(message)
+        get_logger(__name__).warning(message)
     return paragraphs_by_section
 
 def update_section(current_section: Section, paragraph: str, section_markers, sections: List[Section]) -> Section:


### PR DESCRIPTION
# What & Why
#### 1: always return found sections
Until now an error was raised when the helper could not associate text to all sections. This leads to decision being discarded which only lack a single section. For example a section with missing footer will be discarded, even though the other sections might be perfectly usable for tasks down the line. Now the warning is logged by the logger, but the result is returned anyway, preventing empty results.
#### 2: allow to pass custom sections set
There are decisions which concat the facts and considerations into a single section. There are also decision without any footers. As it was not possible to just pass fewer section markers or empty section markers, the functionality has been extended to accept a custom set of sections.

An assertion ensures that the passed section_markers match the passed sections list to prevent errors while developing.

The only section which cannot be removed is the header, which is always included. It does not seem like there are decisions without, so this should be fine.


# Remarks
I'm not sure how well the `get_logger(__name__)` performs. For my testing it seemed too bad so I left it simple for now. Maybe there is a better way to cleanly log warnings.

Also had to update the coverage_report, because as spiders now always return a result even if its empty, the json log will contain empty strings. We have to count sections with actual text, not just the number of elements in a dataframe column.

# Open
I keep getting this message:
```console
Unable to configure handler 'critical_file_handler'
Error in Logging Configuration. Using default config
```
Any idea why this might happen or where it's coming from? Haven't seen this before and it's on the main branch as well.