### PR TITLE
add section splitting for BE_ZivilStraf

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,15 +82,24 @@ git fetch upstream
 git rebase upstream/main
 ```
 
-### Pushing your code
+### Opening a Pull Request
 
-Push the changes to your account using:
+Push the changes to your forked repository using:
 
 ```bash
 git push -u origin a-descriptive-name-for-my-changes
 ```
 
-Then you can go to your GitHub Repository and click on Pull Request, where your codes gets reviewed.
+Then you can go to your GitHub Repository and open a Pull Request to the main branch of the original repository.
+Please make sure to create a good Pull Request by following guidelines such as [How to Make a Perfect Pull Request](https://betterprogramming.pub/how-to-make-a-perfect-pull-request-3578fb4c112). Maybe the following list also serves as a good starting point (https://www.pullrequest.com/blog/writing-a-great-pull-request-description/):
+```
+## What?
+## Why?
+## How?
+## Testing?
+## Screenshots (optional)
+## Anything Else?
+```
 
 ## Tasks
 

--- a/scrc/enums/section.py
+++ b/scrc/enums/section.py
@@ -7,3 +7,7 @@ class Section(Enum):
     CONSIDERATIONS = 'considerations'
     RULINGS = 'rulings'
     FOOTER = 'footer'
+
+    @classmethod
+    def without_facts(cls):
+        return cls.HEADER, cls.CONSIDERATIONS, cls.RULINGS, cls.FOOTER

--- a/scrc/preprocessors/extractors/section_splitter.py
+++ b/scrc/preprocessors/extractors/section_splitter.py
@@ -85,7 +85,9 @@ class SectionSplitter(AbstractExtractor):
             df_chunk = pd.read_json(str(path / f"{chunk}.json"))
             summary['total_collected'] += df_chunk.shape[0]
             for section in Section:
-                summary[section.value] += int((df_chunk[section.value] != '').sum())
+                # count the amount of found sections if the section is not empty
+                if df_chunk.notna()[section.value].any():
+                    summary[section.value] += int((df_chunk[section.value] != '').sum())
 
         if summary['total_collected'] == 0:
             self.logger.info(f"Could not find any stored log files for batch {batch_info['uuid']} in {lang}")
@@ -138,6 +140,7 @@ class SectionSplitter(AbstractExtractor):
                 self.update(engine, df, lang, [section.value for section in Section] + ['paragraphs'], log_dir, filename)
                 self.log_progress(self.chunksize)
                 batchinfo['chunknumber'] += 1
+                self.log_coverage_from_json(engine, spider, lang, batchinfo)
                 
             if self._check_write_privilege(engine):
                 self.log_coverage(engine, spider, lang)


### PR DESCRIPTION
# What & Why
added section splitting for BE_ZivilStraf spider.

# Results
![image](https://user-images.githubusercontent.com/26817152/145447759-aea24faa-e65b-4193-8d08-3a6c257cf4b6.png)

The german parser sadly missed a lot of rulings as the section cannot be distinguished by regex alone.
Example: The first match is within a summary in the considerations section, the other is the header of the ruling:
![image](https://user-images.githubusercontent.com/26817152/145447952-24f88d99-0c79-4ac7-8e2f-08272a14ebdd.png)

There is no easy way to fix this, and none of the possibilites are really worth the effort I'm afraid.

The spider could still be improved, but for the last ~15% of missed sections nearly all are edge-cases with typos or do not have a clean structure.

# Remarks
- This spider does not have a facts section. Facts and considerations are concatenated. I filled them into the considerations section.

# Important
This PR depends on https://github.com/JoelNiklaus/SwissCourtRulingCorpus/pull/26. It will not work otherwise, as it uses the new functionality added in the mentioned PR. Do not merge until the other PR has been accepted.