### PR TITLE
Section splitting for BE_Verwaltungsgericht

### DIFF
--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -177,85 +177,12 @@ def BE_Verwaltungsgericht(decision: Union[bs4.BeautifulSoup, str], namespace: di
     for section, regexes in section_markers.items():
         section_markers[section] = unicodedata.normalize('NFC', regexes)
 
-    def get_paragraphs(soup):
-        """
-        Get Paragraphs in the decision
-        :param soup: the string extracted of the pdf
-        :return: a list of paragraphs
-        """
-
-        paragraphs = []
-        soup = re.sub('\\n', '\\n', soup)
-        lines = soup.split('\n')
-        for element in lines:
-            element = element.replace('  ', ' ')
-            paragraph = clean_text(element)
-            if paragraph not in ['', ' ', None]:
-                paragraphs.append(paragraph)
-        return paragraphs
-
     valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
-    paragraphs = get_paragraphs(decision)
+    paragraphs = get_pdf_paragraphs(decision)
     return associate_sections(paragraphs, section_markers, namespace)
-
-def BE_Steuerrekurs(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
-    """
-    :param decision:    the decision parsed by bs4 or the string extracted of the pdf
-    :param namespace:   the namespace containing some metadata of the court decision
-    :return:            the sections dict (keys: section, values: list of paragraphs)
-    """
-    all_section_markers = {
-        Language.DE: {
-            Section.HEADER: [r'STEUERREKURSKOMMISSION DES KANTONS BERN'],
-            Section.FACTS: [r'(hat die Steuerrekurskommission den )*Akten entnommen:'],
-            Section.CONSIDERATIONS: [r'Die Steuerrekurskommission zieht in Erwägung:'],
-            Section.RULINGS: [r'Aus diesen Gründen wird erkannt:'],
-            Section.FOOTER: [r'IM NAMEN DER STEUERREKURSKOMMISSION']
-         },
-
-        Language.FR: {
-            Section.HEADER: [r'COMMISSION DES RECOURS'],
-            Section.FACTS: [r'(La Commission des recours en matière fiscale )*constate en fait:'],
-            Section.CONSIDERATIONS: [r'La Commission des recours en matière fiscale considère en droit:'],
-            Section.RULINGS: [r'Par ces motifs, la Commission des recours en matière fiscale prononce:'],
-            Section.FOOTER: [r'AU NOM DE LA COMMISSION DES RECOURS']
-        }
-    }
-
-    if namespace['language'] not in all_section_markers:
-        message = f"This function is only implemented for the languages {list(all_section_markers.keys())} so far."
-        raise ValueError(message)
-
-    section_markers = all_section_markers[namespace['language']]
-    # combine multiple regex into one for each section due to performance reasons
-    section_markers = dict(map(lambda kv: (kv[0], '|'.join(kv[1])), section_markers.items()))
-
-    # normalize strings to avoid problems with umlauts
-    for section, regexes in section_markers.items():
-        section_markers[section] = unicodedata.normalize('NFC', regexes)
-
-    def get_paragraphs(soup):
-        """
-        Get Paragraphs in the decision
-        :param soup: the string extracted of the pdf
-        :return: a list of paragraphs
-        """
-        paragraphs = []
-        soup = re.sub('\\n +\\n', '\\n\\n', soup)
-        lines = soup.split('\n\n')
-        for element in lines:
-            element = element.replace('  ', ' ')
-            paragraph = clean_text(element)
-            if paragraph not in ['', ' ', None]:
-                paragraphs.append(paragraph)
-        return paragraphs
-
-    paragraphs = get_paragraphs(decision)
-    return associate_sections(paragraphs, section_markers, namespace)
-
 
 def BS_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     """

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -135,7 +135,71 @@ def BE_ZivilStraf(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> O
                 to_ = sorted_section_pos[i+1]
             paragraphs_by_section[actual_section].append(decision[from_:to_])
     
-    return paragraphs_by_section        
+    return paragraphs_by_section
+
+def BE_Verwaltungsgericht(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
+    """
+    :param decision:    the decision parsed by bs4 or the string extracted of the pdf
+    :param namespace:   the namespace containing some metadata of the court decision
+    :return:            the sections dict (keys: section, values: list of paragraphs)
+    """
+
+    all_section_markers = {
+        Language.DE: {
+            Section.HEADER: [r'Verwaltungsgericht des Kantons Bern', r'Beschluss', r'SK\-*\s*Nr\.\s\d*/\d*',
+                             r'\w*\-*\s*\d*\/*\s*\-*\d*\,\s(\w+\s)*\d{4}\s*\d*'],
+            Section.FACTS: [r'Sachverhalt( und Erwägungen)*:', r'Regeste(:)*'],
+            Section.CONSIDERATIONS: [r'Erwägungen:',
+                                     r'(Der|Die|Das)\s\w+\s*(.+)\s*(e|E)rwäg(t|ung)(:)*(\,\s*dass)*(:)*'],
+            Section.RULINGS: [r'Demnach entscheidet\s\w+\s*(.+)\s*:'],
+            Section.FOOTER: [r'Rechtsmittelbelehrung']
+        },
+
+        Language.FR: {
+            Section.HEADER: [r'Tribunal administratif du canton de Berne', r'\w+\-\d*\s\d*\,\s(\w+\s)*\d{4}',
+                             r'Décision', r'\w*\s*\d*\s*\d*\,*\s*(\w+\.*\s)*\d{2}'],
+            Section.FACTS: [r'En fait:'],
+            Section.CONSIDERATIONS: [r'En droit:'],
+            Section.RULINGS: [r'Par ces motifs:'],
+            Section.FOOTER: [r'Voie de recours']
+        }
+    }
+
+    if namespace['language'] not in all_section_markers:
+        message = f"This function is only implemented for the languages {list(all_section_markers.keys())} so far."
+        raise ValueError(message)
+
+    section_markers = all_section_markers[namespace['language']]
+    # combine multiple regex into one for each section due to performance reasons
+    section_markers = dict(map(lambda kv: (kv[0], '|'.join(kv[1])), section_markers.items()))
+
+    # normalize strings to avoid problems with umlauts
+    for section, regexes in section_markers.items():
+        section_markers[section] = unicodedata.normalize('NFC', regexes)
+
+    def get_paragraphs(soup):
+        """
+        Get Paragraphs in the decision
+        :param soup: the string extracted of the pdf
+        :return: a list of paragraphs
+        """
+
+        paragraphs = []
+        soup = re.sub('\\n', '\\n', soup)
+        lines = soup.split('\n')
+        for element in lines:
+            element = element.replace('  ', ' ')
+            paragraph = clean_text(element)
+            if paragraph not in ['', ' ', None]:
+                paragraphs.append(paragraph)
+        return paragraphs
+
+    valid_namespace(namespace, all_section_markers)
+
+    section_markers = prepare_section_markers(all_section_markers, namespace)
+
+    paragraphs = get_paragraphs(decision)
+    return associate_sections(paragraphs, section_markers, namespace)
 
 def BS_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     """


### PR DESCRIPTION
Added the section splitting for the following spider: BE_Verwaltungsgericht.

Results for DE language:
- Header:  6598 / 6598 (100.00%)
- Facts:   6400 / 6598 (97.00%) 
- Considerations:  6482 / 6598 (98.24%) 
- Rulings: 6418 / 6598 (97.27%) 
- Footer:  6596 / 6598 (99.97%) 

Results for FR language: 
- Header:  679 / 679 (100.00%) 
- Facts:   662 / 679 (97.50%)
- Considerations:  661 / 679 (97.35%) 
- Rulings: 679 / 679 (100.00%) 
- Footer:  679 / 679 (100.00%)

Remark: 
- two decisions without footer
 