### PR TITLE
Section splitting for BE_Steuerrekurs

### DIFF
--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -184,6 +184,45 @@ def BE_Verwaltungsgericht(decision: Union[bs4.BeautifulSoup, str], namespace: di
     paragraphs = get_pdf_paragraphs(decision)
     return associate_sections(paragraphs, section_markers, namespace)
 
+def BE_Steuerrekurs(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
+    """
+    :param decision:    the decision parsed by bs4 or the string extracted of the pdf
+    :param namespace:   the namespace containing some metadata of the court decision
+    :return:            the sections dict (keys: section, values: list of paragraphs)
+    """
+    all_section_markers = {
+        Language.DE: {
+            Section.HEADER: [r'STEUERREKURSKOMMISSION DES KANTONS BERN'],
+            Section.FACTS: [r'(hat die Steuerrekurskommission den )*Akten entnommen:'],
+            Section.CONSIDERATIONS: [r'Die Steuerrekurskommission zieht in Erwägung:'],
+            Section.RULINGS: [r'Aus diesen Gründen wird erkannt:'],
+            Section.FOOTER: [r'IM NAMEN DER STEUERREKURSKOMMISSION']
+         },
+
+        Language.FR: {
+            Section.HEADER: [r'COMMISSION DES RECOURS'],
+            Section.FACTS: [r'(La Commission des recours en matière fiscale )*constate en fait:'],
+            Section.CONSIDERATIONS: [r'La Commission des recours en matière fiscale considère en droit:'],
+            Section.RULINGS: [r'Par ces motifs, la Commission des recours en matière fiscale prononce:'],
+            Section.FOOTER: [r'AU NOM DE LA COMMISSION DES RECOURS']
+        }
+    }
+
+    if namespace['language'] not in all_section_markers:
+        message = f"This function is only implemented for the languages {list(all_section_markers.keys())} so far."
+        raise ValueError(message)
+
+    section_markers = all_section_markers[namespace['language']]
+    # combine multiple regex into one for each section due to performance reasons
+    section_markers = dict(map(lambda kv: (kv[0], '|'.join(kv[1])), section_markers.items()))
+
+    # normalize strings to avoid problems with umlauts
+    for section, regexes in section_markers.items():
+        section_markers[section] = unicodedata.normalize('NFC', regexes)
+
+    paragraphs = get_pdf_paragraphs(decision)
+    return associate_sections(paragraphs, section_markers, namespace)
+
 def BS_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     """
     :param decision:    the decision parsed by bs4 or the string extracted of the pdf


### PR DESCRIPTION
//Divided the two spiders from PR #41

Added the section splitting for the following spider: BE_Steuerrekurs.

Results for DE language:

- Header: 107 / 107 (100.00%)
- Facts: 106 / 107 (99.07%)
- Considerations: 107 / 107 (100.00%)
- Rulings: 106 / 107 (99.07%)
- Footer: 107 / 107 (100.00%)

Results for FR language:

- Header: 12 / 12 (100.00%)
- Facts: 11 / 12 (91.67%)
- Considerations: 12 / 12 (100.00%)
- Rulings: 12 / 12 (100.00%)
- Footer: 12 / 12 (100.00%)