### PR TITLE
Section splitting for GR_Gerichte

### DIFF
--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -184,45 +184,6 @@ def BE_Verwaltungsgericht(decision: Union[bs4.BeautifulSoup, str], namespace: di
     paragraphs = get_pdf_paragraphs(decision)
     return associate_sections(paragraphs, section_markers, namespace)
 
-def BE_Steuerrekurs(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
-    """
-    :param decision:    the decision parsed by bs4 or the string extracted of the pdf
-    :param namespace:   the namespace containing some metadata of the court decision
-    :return:            the sections dict (keys: section, values: list of paragraphs)
-    """
-    all_section_markers = {
-        Language.DE: {
-            Section.HEADER: [r'STEUERREKURSKOMMISSION DES KANTONS BERN'],
-            Section.FACTS: [r'(hat die Steuerrekurskommission den )*Akten entnommen:'],
-            Section.CONSIDERATIONS: [r'Die Steuerrekurskommission zieht in Erwägung:'],
-            Section.RULINGS: [r'Aus diesen Gründen wird erkannt:'],
-            Section.FOOTER: [r'IM NAMEN DER STEUERREKURSKOMMISSION']
-         },
-
-        Language.FR: {
-            Section.HEADER: [r'COMMISSION DES RECOURS'],
-            Section.FACTS: [r'(La Commission des recours en matière fiscale )*constate en fait:'],
-            Section.CONSIDERATIONS: [r'La Commission des recours en matière fiscale considère en droit:'],
-            Section.RULINGS: [r'Par ces motifs, la Commission des recours en matière fiscale prononce:'],
-            Section.FOOTER: [r'AU NOM DE LA COMMISSION DES RECOURS']
-        }
-    }
-
-    if namespace['language'] not in all_section_markers:
-        message = f"This function is only implemented for the languages {list(all_section_markers.keys())} so far."
-        raise ValueError(message)
-
-    section_markers = all_section_markers[namespace['language']]
-    # combine multiple regex into one for each section due to performance reasons
-    section_markers = dict(map(lambda kv: (kv[0], '|'.join(kv[1])), section_markers.items()))
-
-    # normalize strings to avoid problems with umlauts
-    for section, regexes in section_markers.items():
-        section_markers[section] = unicodedata.normalize('NFC', regexes)
-
-    paragraphs = get_pdf_paragraphs(decision)
-    return associate_sections(paragraphs, section_markers, namespace)
-
 def GR_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     """
     :param decision:    the decision parsed by bs4 or the string extracted of the pdf

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -184,6 +184,45 @@ def BE_Verwaltungsgericht(decision: Union[bs4.BeautifulSoup, str], namespace: di
     paragraphs = get_pdf_paragraphs(decision)
     return associate_sections(paragraphs, section_markers, namespace)
 
+def BE_Steuerrekurs(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
+    """
+    :param decision:    the decision parsed by bs4 or the string extracted of the pdf
+    :param namespace:   the namespace containing some metadata of the court decision
+    :return:            the sections dict (keys: section, values: list of paragraphs)
+    """
+    all_section_markers = {
+        Language.DE: {
+            Section.HEADER: [r'STEUERREKURSKOMMISSION DES KANTONS BERN'],
+            Section.FACTS: [r'(hat die Steuerrekurskommission den )*Akten entnommen:'],
+            Section.CONSIDERATIONS: [r'Die Steuerrekurskommission zieht in Erwägung:'],
+            Section.RULINGS: [r'Aus diesen Gründen wird erkannt:'],
+            Section.FOOTER: [r'IM NAMEN DER STEUERREKURSKOMMISSION']
+         },
+
+        Language.FR: {
+            Section.HEADER: [r'COMMISSION DES RECOURS'],
+            Section.FACTS: [r'(La Commission des recours en matière fiscale )*constate en fait:'],
+            Section.CONSIDERATIONS: [r'La Commission des recours en matière fiscale considère en droit:'],
+            Section.RULINGS: [r'Par ces motifs, la Commission des recours en matière fiscale prononce:'],
+            Section.FOOTER: [r'AU NOM DE LA COMMISSION DES RECOURS']
+        }
+    }
+
+    if namespace['language'] not in all_section_markers:
+        message = f"This function is only implemented for the languages {list(all_section_markers.keys())} so far."
+        raise ValueError(message)
+
+    section_markers = all_section_markers[namespace['language']]
+    # combine multiple regex into one for each section due to performance reasons
+    section_markers = dict(map(lambda kv: (kv[0], '|'.join(kv[1])), section_markers.items()))
+
+    # normalize strings to avoid problems with umlauts
+    for section, regexes in section_markers.items():
+        section_markers[section] = unicodedata.normalize('NFC', regexes)
+
+    paragraphs = get_pdf_paragraphs(decision)
+    return associate_sections(paragraphs, section_markers, namespace)
+
 def BS_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     """
     :param decision:    the decision parsed by bs4 or the string extracted of the pdf

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -207,17 +207,15 @@ def GR_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
             Section.HEADER: [r'TRIBUNALE AMMINISTRATIVO DEL CANTONE DEI GRIGIONI', r'Tribunale cantonale dei Grigioni', r'Dretgira chantunala dal Grischun'],
             Section.FACTS: [r'concernente\s*\w*\s*\w*'],
             Section.CONSIDERATIONS: [r'\s*Considerando\s*in\s*diritto\s*:\s*', r'(in )*constatazione e in considerazione,',
-                                     r'La (Presidenza|Commissione) del Tribunale cantonale considera :',
-                                     r'Considerandi', r'La Camera (di gravame|civile) considera :', r'La derschadra singula tira en consideraziun:',
-                                     r'In considerazione:', r'visto e considerato:',
-                                     r'Considerato in fatto e in diritto:', r'La dertgira trai en consideraziun:',
-                                     r'Il derschader singul trai en consideraziun:'],
+                                     r'La (Presidenza|Commissione) del Tribunale cantonale considera :', r'Considerandi', 
+                                     r'La Camera (di gravame|civile) considera :', r'In considerazione:', r'visto e considerato:',
+                                     r'Considerato in fatto e in diritto:', r'^((La|Il)\s(\w+\s)*en consideraziun:)$'],
             Section.RULINGS: [r'^(((L|l)a (Prima|Seconda) )*Camera (penale|civile) (pronuncia|giudica|decreta|decide|ordina|considera)\s*:)',
                               r'Decisione \─ Dispositivo', r'Per questi motivi il Tribunale giudica:', r'Il Tribunale decide:',
                               r'La (Presidenza|Commissione) del Tribunale cantonale (ordina|giudica:)', r'La Camera di gravame (considera|decide) :', r'Per questi motivi si decreta:',
                               r'(La )*Camera civile giudica:', r'decide:', r'(la Presidenza )ordina\s*(:)*', r'(Si )*giudica',
                               r'La Camera delle esecuzioni e dei fallimenti decide:', r'(i|I)l Giudice unico decide:',
-                              r'decreta', r'(Il derschader singul|La dertgira) decida damai:'],
+                              r'decreta', r'^((La|Il)\s(\w+\s)*decida damai:)$', r'^(è giudicato:)$'],
             Section.FOOTER: [r'Per la Presidenza del Tribunale cantonale dei Grigioni']
         }
     }


### PR DESCRIPTION
Added the section splitting for the following spider: GR_Gerichte.

Results for DE language:
- Header: 10301 / 10301 (100.00%) 
- Facts:  9542 / 10301 (92.63%) 
- Considerations: 9542 / 10301 (92.63%) 
- Rulings:        8760 / 10301 (85.04%) 
- Footer: 900 / 10301 (8.74%) 

Results for IT language:
- Header: 1006 / 1006 (100.00%) 
- Facts:  847 / 1006 (84.19%) 
- Considerations: 640 / 1006 (63.62%) 
- Rulings:        941 / 1006 (93.54%) 
- Footer: 14 / 1006 (1.39%) 

Remarks:
-nearly all of them do not have a footer
-some decisions are missing "Considerations"
-found decisions that are probably written in Romansh  [example:](https://entscheidsuche.gr.ch/tribunavtplus/ServletDownload/A_2016_29_754e9e8689c344e7876786069ed75ffc.pdf?path=b7575f62f2ae80f012d42c5d583ce4c1c246bfce97cd964659465e2e510ba28d79f68185109ce53637af19deee5ffed56a7abf2b4c69352723ca35ddc19f64ca0ee824e14822b86d4ab5cf317103e185&pathIsEncrypted=1&dossiernummer=A_2016_29)
-there are are also some interesting looking decisions(not handled): 
1.  [example1](https://entscheidsuche.gr.ch/tribunavtplus/ServletDownload/PVG_2017_31_4c24576cf839487bb4aa325d5d38b4bf.pdf?path=b7575f62f2ae80f012d42c5d583ce4c1c246bfce97cd964659465e2e510ba28d3dacd5df4b326cf544b78030fcdd5e3a31c10ad5b64b828ead2a7695fd7142140ee824e14822b86d4ab5cf317103e185&pathIsEncrypted=1&dossiernummer=PVG_2017_31)
2.  [example 2](https://entscheidsuche.gr.ch/tribunavtplus/ServletDownload/PVG_2017_30_ad3ea052bc534529ad03caed511721a3.pdf?path=b7575f62f2ae80f012d42c5d583ce4c1c246bfce97cd964659465e2e510ba28db8c857f8d36fd9df129e1cd97f178e9f2dfa99fa5d64985b1dc847030b5e81690ee824e14822b86d4ab5cf317103e185&pathIsEncrypted=1&dossiernummer=PVG_2017_30)
