### PR TITLE
Section splitting for SO_Omni

### DIFF
--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -286,7 +286,7 @@ def SO_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
     """
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [r'(Beschluss|Urteil|Entscheid)\svom\s\d*\.*\s(Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)\s\d*', r'Geschäftsnummer:'],
+            Section.HEADER: [r'(Beschluss|Urteil|Entscheid)\svom\s\d*\.*\s(Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)\s\d*'],
             Section.FACTS: [r'Sachverhalt\s*(gekürzt)*:', r'In Sachen'],
             Section.CONSIDERATIONS: [r'(Aus den )*Erwägungen:', r'zieht\s\w+\s*(.+)\s*Erwägung(en)*(:)*(, dass)*(:)*'],
             Section.RULINGS: [r'Demnach wird (erkannt|beschlossen|verfügt):', r'^(erkannt:$)', r'(beschlossen|festgestellt) und erkannt:', r'Demnach wird\s\w+\s*(.+)\s*(beschlossen|erkannt|verfügt):'],

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -286,11 +286,11 @@ def SO_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
     """
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [r'(Beschluss|Urteil|Entscheid)\svom\s\d*\.*\s(Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)\s\d*'],
-            Section.FACTS: [r'Sachverhalt\s*(gekürzt)*:', r'In Sachen'],
-            Section.CONSIDERATIONS: [r'(Aus den )*Erwägungen:', r'zieht\s\w+\s*(.+)\s*Erwägung(en)*(:)*(, dass)*(:)*'],
-            Section.RULINGS: [r'Demnach wird (erkannt|beschlossen|verfügt):', r'^(erkannt:$)', r'(beschlossen|festgestellt) und erkannt:', r'Demnach wird\s\w+\s*(.+)\s*(beschlossen|erkannt|verfügt):'],
-            Section.FOOTER: [r'^(Rechtsmittel(\sbelehrung)*(:)*)$', r'(Rechtsmittel:\s*)']
+            Section.HEADER: [r'^((Beschluss|Urteil|Entscheid)\svom\s\d*\.*\s(Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)\s\d*)', r'^((SOG|KSGE) \d* Nr\. \d*)$'],
+            Section.FACTS: [r'^(Sachverhalt\s*(gekürzt)*:*)$', r'^(In Sachen)'],
+            Section.CONSIDERATIONS: [r'^((Aus den )*Erwägungen:*)$', r'^(zieht\s\w+\s*(.+)\s*Erwägung(en)*(:)*(, dass)*(:)*)', r'^((Die|Der|Das)\s(\w+\s)*zieht in Erwägung:)$'],
+            Section.RULINGS: [r'^(Demnach wird (erkannt|beschlossen|verfügt):)$', r'^(erkannt:)$', r'^((beschlossen|festgestellt) und erkannt:)', r'^(Demnach wird\s\w+\s*(.+)\s*(beschlossen|erkannt|verfügt):)'],
+            Section.FOOTER: [r'^(Rechtsmittel(\sbelehrung)*(:)*)']
         }
     }
 

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -239,6 +239,30 @@ def VD_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
     paragraphs = get_paragraphs(divs)
     return associate_sections(paragraphs, section_markers, namespace)
 
+def SO_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
+    """
+    :param decision:    the decision parsed by bs4 or the string extracted of the pdf
+    :param namespace:   the namespace containing some metadata of the court decision
+    :return:            the sections dict (keys: section, values: list of paragraphs)
+    """
+    all_section_markers = {
+        Language.DE: {
+            Section.HEADER: [r'(Beschluss|Urteil|Entscheid)\svom\s\d*\.*\s(Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)\s\d*', r'Geschäftsnummer:'],
+            Section.FACTS: [r'Sachverhalt\s*(gekürzt)*:', r'In Sachen'],
+            Section.CONSIDERATIONS: [r'(Aus den )*Erwägungen:', r'zieht\s\w+\s*(.+)\s*Erwägung(en)*(:)*(, dass)*(:)*'],
+            Section.RULINGS: [r'Demnach wird (erkannt|beschlossen|verfügt):', r'^(erkannt:$)', r'(beschlossen|festgestellt) und erkannt:', r'Demnach wird\s\w+\s*(.+)\s*(beschlossen|erkannt|verfügt):'],
+            Section.FOOTER: [r'^(Rechtsmittel(\sbelehrung)*(:)*)$', r'(Rechtsmittel:\s*)']
+        }
+    }
+
+    valid_namespace(namespace, all_section_markers)
+
+    section_markers = prepare_section_markers(all_section_markers, namespace)
+
+    divs = decision.find_all(
+        "div", class_=['WordSection1'])
+    paragraphs = get_paragraphs(divs)
+    return associate_sections(paragraphs, section_markers, namespace)
 
 def CH_BGer(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     """


### PR DESCRIPTION
Added the section splitting for the following spider: SO_Omni.

First of all, I think it is important to mention that I am being shown an odd number of decisions: 9k, while they should probably be around 5k. Therefore, I do not know how trustworthy my numbers are.
On top of this, I have the feeling there are decisions that are not on [Entscheidsuche](https://entscheidsuche.ch/). Why do I believe so it is because I searched, for example, for a decision from 15 December 2007 that did show up in my terminal, but it does not exist on the website under Solothurn.

**Results for DE language:**
- Header: 9293 / 9293 (100.00%) 
- Facts:  6923 / 9293 (74.50%) 
- Considerations: 7036 / 9293 (75.71%) 
- Rulings:        5703 / 9293 (61.37%) 
- Footer: 5740 / 9293 (61.77%)

**Remarks:**
There are mainly two types of "formats" for our decisions for this spider:

1.  [Type 1](https://entscheidsuche.ch/docs/SO_Omni/SO_OG_006_STBER-2015-33_2016-06-22.html )
2.  [Type 2](https://entscheidsuche.ch/docs/SO_Omni/SO_OG_004_ZKBER-2019-11_2019-04-04.html)

For _type 1_, the decisions have the tendency to be quite messy:
- I believe that most of them (actually, maybe even all of them), do not have "Rulings" or "Footer". Or if they do(I do not know this) they could probably be in the text, without a keyword that delimits them, such as "erkannt". But for me, even with a translator is too difficult to separate them. Therefore I recommend that someone who can speak German checks them.
- More, there are decisions like [this one](https://gerichtsentscheide.so.ch/cgi-bin/nph-omniscgi.exe?OmnisPlatform=WINDOWS&WebServerUrl=https://gerichtsentscheide.so.ch&WebServerScript=/cgi-bin/nph-omniscgi.exe&OmnisLibrary=JURISWEB&OmnisClass=rtFindinfoWebHtmlService&OmnisServer=7001&Parametername=WEB&Schema=JGWEB&Source=&Aufruf=getMarkupDocument&cSprache=DE&nF30_KEY=127731&W10_KEY=3581943&nTrefferzeile=50&Template=/simple/search_result_document.html) that do not have "keywords" to separate the sections, therefore it is hard for me to determine where the paragraphs belong to (FACTS, RULINGS, etc.)
-  Or there are also decisions that have very short paragraphs - [example](https://gerichtsentscheide.so.ch/cgi-bin/nph-omniscgi.exe?OmnisPlatform=WINDOWS&WebServerUrl=https://gerichtsentscheide.so.ch&WebServerScript=/cgi-bin/nph-omniscgi.exe&OmnisLibrary=JURISWEB&OmnisClass=rtFindinfoWebHtmlService&OmnisServer=7001&Parametername=WEB&Schema=JGWEB&Source=&Aufruf=getMarkupDocument&cSprache=DE&nF30_KEY=126549&W10_KEY=5224035&nTrefferzeile=48&Template=/simple/search_result_document.html)

For _type 2_, the decisions should be mostly fine as they are neatly written.


In conclusion, I did check a bunch of decisions and they seem to be splitted correctly. This, of course, for the ones I could. I can not promise the same for the "unusual" decisions.

