### PR TITLE
Section splitting for CH_BSTG

### DIFF
--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -344,27 +344,36 @@ def CH_BSTG(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
     """
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [r'(Verfügung|Beschluss|Urteil|Entscheid) vom \d*\.* (Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)\s\d*'],
+            Section.HEADER: [r'^((Verfügung|Beschluss|Urteil|Entscheid|Präsidialverfügung|Präsidialentscheid) vom \d*\.* (Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)\s\d*)',
+                             r'^(Präsidialentscheid vom )$'],
             Section.FACTS: [r'^(Sachverhalt(:)*)$', r'Prozessgeschichte(:)*', r'(Die|Der)\s\w+\s*(.+)\s*hält fest, dass\s*(:*)'],
-            Section.CONSIDERATIONS: [r'^(Nach Einsicht in)$', r'^([iI]n\sErwägung(:)*)', r'^(Erwägungen:*)$', r'(Die|Der|Das|Aus)(\s([\w\.])*)*\s[eE]rwäg\w*(\,\sdass)*\s*(:)*'],
-            Section.RULINGS: [r'^(und (verfugt|erkennt|beschliesst)(:)*)$', r'^(p*(Die|Der|Das|und)(\s(\w|\.)*)*\s(verfügt|erkennt|beschliesst)(:)*)$', r'^(Demnach (erkennt|verfügt|beschliesst)\s\w+\s*(.+)\s\w*(:)*)'],
-            Section.FOOTER: [r'^(Rechtsmittelbelehrung)$']
+            Section.CONSIDERATIONS: [r'^(Nach Einsicht in)$', r'^([iI]n\sErwägung(:)*)', r'^(Erwägungen:*)$', r'(Die|Der|Das|Aus)(\s([\w\.])*)*\s[eE]rwäg\w*(\,\sdass)*\s*(:)*\s*'],
+            Section.RULINGS: [r'^(und (verfügt|erkennt|beschliesst)(:)*\s*)$', r'^(p*(Die|Der|Das|und)(\s(\w|\.)*)*\s(verfügt|erkennt|beschliesst)(:)*)$',
+                              r'^(Demnach (erkennt|verfügt|beschliesst)\s\w+\s*(.+)\s\w*(:)*)', r'^(beschliesst die Strafkammer:)$'],
+            Section.FOOTER: [r'^(Rechtsmittelbelehrung)', r'^(Hinweis:*( auf Art\. 78 BGG| auf das Bundesgerichtsgesetz \(BGG, SR 173\.110\)| auf die Rechtsmittelordnung)*)$',
+                             r'^(Beschwerde an die Beschwerdekammer des Bundesstrafgerichts)', r'^(Nach Eintritt der Rechtskraft mitzuteilen an:*)', r'^(Zustellung an\s*)$',
+                             r'Gegen Entscheide der Strafkammer des Bundesstrafgerichts']
         },
 
         Language.FR: {
-            Section.HEADER: [r'^((Arrêt|Ordonnance|Décision) du \d*\W*\s(janvier|février|mars|avril|mai|juin|juillet|août|septembre|octobre|novembre|décembre)\s\d*)$'],
+            Section.HEADER: [r'^((Arrêt|Ordonnance|Décision|Jugement) du \d*\W*\s(janvier|février|mars|avril|mai|juin|juillet|août|septembre|octobre|novembre|décembre)\s\d*)$'],
             Section.FACTS: [r'^((F|f)(AITS|aits)(:)*)', r'(La|Le)*(\s\w*)*\s*(\,\s)*(V|v)u\s*(:)*(que)*(:)*(\sle dossier de la cause)*'],
-            Section.CONSIDERATIONS: [r'(et|Et)*\s*(C|c)onsidérant\s*(que)*:', r'La Cour d’appel considère(\s)*:', r'DROIT', r'(La|Le|Considérant)(\s\w+\s*(.+)\s*)(considère|et) en droit:'],
-            Section.RULINGS: [r'Ordonne:', r'(La|Le)\s\w+\s*(.+)\s(prononce|décide)\s*(:)', r'^(pronnonce\s*(:))', r'Par ces motifs\,(\s\w*)*\s(prononce|decide):'],
-            Section.FOOTER: [r'Indication des voies de (recours|droit)', r'Voies de droit']
+            Section.CONSIDERATIONS: [r'(et|Et)*\s*(C|c)onsidérant\s*(que)*:\s*', r'La Cour d’appel considère(\s)*:', r'DROIT', r'(La|Le|Considérant)(\s\w+\s*(.+)\s*)(considère|et) en droit:'],
+            Section.RULINGS: [r'Ordonne:', r'(La|Le)\s\w+\s*(.+)\s(prononce|décide)\s*(:)', r'^(pronnonce\s*(:))', r'Par ces motifs\,(\s\w*)*\s(prononce|décide|ordonne)\s*:\s*'],
+            Section.FOOTER: [r'Indication(s)* des voies de (recours|droit|plainte)', r'Voies de droit',  r'^(Distribution\s*(\(\s*acte judiciaire\)):*\s*)',
+                             r'Appel à la Cour d’appel du Tribunal pénal fédéral', r'^(Une expédition complète de la décision est adressée à)',
+                             r'^(Distribution\s*(\(\s*recommandé\)):*\s*)', r'^(Notification des voies de recours)']
         },
 
         Language.IT: {
-            Section.HEADER: [r'^((Sentenza|Decisione|Ordinanza)\s*del(l)*\W*\d*\W*\s*(gennaio|febbraio|marzo|aprile|maggio|luglio|agosto|settembre|ottobre|novembre|dicembre|giugno)\s*\d*)$'],
+            Section.HEADER: [r'^((Sentenza|Decisione(\ssupercautelare)*|Ordinanza|Decreto)\s*del(l)*\W*\d*\W*\s*(gennaio|febbraio|marzo|aprile|maggio|luglio|agosto|settembre|ottobre|novembre|dicembre|giugno)\s*\d*)$'],
             Section.FACTS: [r'^([Ff]att(i|o)\s*:)$', r'Visti:', r'^(\w+\s*(.+)\s*penali, vist(o|i)\s*(:)*)', r'(Ritenuto )*in fatto( e(d)* in diritto):'],
-            Section.CONSIDERATIONS: [r'^((e\s)*[Cc]onsiderato:?\s*)$', '^([Dd]iritto:?\s*)$', r'La Corte(\sd\'appello)* considera in diritto:', r'^(In diritto:)$'],
-            Section.RULINGS: [r'La Corte (decreta|pronuncia|ordina):', r'Per questi motivi\,(\s\w*)*\s(decreta|ordina|pronuncia):', r'Il Giudice unico pronuncia:', r'^(Decreta:)$'],
-            Section.FOOTER: [r'(Informazione\ssui\s)*[Rr]imedi\sgiuridici', r'Reclamo alla Corte dei reclami penali del Tribunale penale federale']
+            Section.CONSIDERATIONS: [r'^((e\s)*[Cc]onsiderato:?\s*)$', '^([Dd]iritto(:)*\s*)$', r'^(La Corte considera in fatto e in diritto:)',
+                                     r'La Corte(\sd(\'|\’)appello)* considera in diritto:', r'^(In diritto:)$'],
+            Section.RULINGS: [r'La Corte (decreta|pronuncia|ordina):', r'^(Per questi motivi(\,)*(\s\w*)*\s(decreta|ordina|pronuncia):)$', r'^((Per questi motivi, )*[Ll]a I(I)*(\.)* Corte dei reclami penali pronuncia:\s*)$',
+                              r'Il Giudice unico pronuncia:', r'^(Decreta:)$', r'^(Il Presidente decreta:)'],
+            Section.FOOTER: [r'(Informazione\ssui\s)*[Rr]imedi\sgiuridici', r'^(Intimazione a:)', r'^(Il testo integrale della sentenza viene notificato a:)', r'^(Comunicazione a(:)*\s*)$',
+                             r'Reclamo alla Corte dei reclami penali del Tribunale penale federale', r'^(Comunicazione \(atto giudiziale\) a:)']
         }
     }
 
@@ -382,7 +391,6 @@ def CH_BSTG(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
 
     paragraphs = get_pdf_paragraphs(decision)
     return associate_sections(paragraphs, section_markers, namespace)
-
 
 def get_paragraphs(divs):
     # """

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -336,6 +336,54 @@ def CH_BGer(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
     paragraphs = get_paragraphs(decision)
     return associate_sections(paragraphs, section_markers, namespace)
 
+def CH_BSTG(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
+    """
+    :param decision:    the decision parsed by bs4 or the string extracted of the pdf
+    :param namespace:   the namespace containing some metadata of the court decision
+    :return:            the sections dict (keys: section, values: list of paragraphs)
+    """
+    all_section_markers = {
+        Language.DE: {
+            Section.HEADER: [r'(Verfügung|Beschluss|Urteil|Entscheid) vom \d*\.* (Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)\s\d*'],
+            Section.FACTS: [r'^(Sachverhalt(:)*)$', r'Prozessgeschichte(:)*', r'(Die|Der)\s\w+\s*(.+)\s*hält fest, dass\s*(:*)'],
+            Section.CONSIDERATIONS: [r'^(Nach Einsicht in)$', r'^([iI]n\sErwägung(:)*)', r'^(Erwägungen:*)$', r'(Die|Der|Das|Aus)(\s([\w\.])*)*\s[eE]rwäg\w*(\,\sdass)*\s*(:)*'],
+            Section.RULINGS: [r'^(und (verfugt|erkennt|beschliesst)(:)*)$', r'^(p*(Die|Der|Das|und)(\s(\w|\.)*)*\s(verfügt|erkennt|beschliesst)(:)*)$', r'^(Demnach (erkennt|verfügt|beschliesst)\s\w+\s*(.+)\s\w*(:)*)'],
+            Section.FOOTER: [r'^(Rechtsmittelbelehrung)$']
+        },
+
+        Language.FR: {
+            Section.HEADER: [r'^((Arrêt|Ordonnance|Décision) du \d*\W*\s(janvier|février|mars|avril|mai|juin|juillet|août|septembre|octobre|novembre|décembre)\s\d*)$'],
+            Section.FACTS: [r'^((F|f)(AITS|aits)(:)*)', r'(La|Le)*(\s\w*)*\s*(\,\s)*(V|v)u\s*(:)*(que)*(:)*(\sle dossier de la cause)*'],
+            Section.CONSIDERATIONS: [r'(et|Et)*\s*(C|c)onsidérant\s*(que)*:', r'La Cour d’appel considère(\s)*:', r'DROIT', r'(La|Le|Considérant)(\s\w+\s*(.+)\s*)(considère|et) en droit:'],
+            Section.RULINGS: [r'Ordonne:', r'(La|Le)\s\w+\s*(.+)\s(prononce|décide)\s*(:)', r'^(pronnonce\s*(:))', r'Par ces motifs\,(\s\w*)*\s(prononce|decide):'],
+            Section.FOOTER: [r'Indication des voies de (recours|droit)', r'Voies de droit']
+        },
+
+        Language.IT: {
+            Section.HEADER: [r'^((Sentenza|Decisione|Ordinanza)\s*del(l)*\W*\d*\W*\s*(gennaio|febbraio|marzo|aprile|maggio|luglio|agosto|settembre|ottobre|novembre|dicembre|giugno)\s*\d*)$'],
+            Section.FACTS: [r'^([Ff]att(i|o)\s*:)$', r'Visti:', r'^(\w+\s*(.+)\s*penali, vist(o|i)\s*(:)*)', r'(Ritenuto )*in fatto( e(d)* in diritto):'],
+            Section.CONSIDERATIONS: [r'^((e\s)*[Cc]onsiderato:?\s*)$', '^([Dd]iritto:?\s*)$', r'La Corte(\sd\'appello)* considera in diritto:', r'^(In diritto:)$'],
+            Section.RULINGS: [r'La Corte (decreta|pronuncia|ordina):', r'Per questi motivi\,(\s\w*)*\s(decreta|ordina|pronuncia):', r'Il Giudice unico pronuncia:', r'^(Decreta:)$'],
+            Section.FOOTER: [r'(Informazione\ssui\s)*[Rr]imedi\sgiuridici', r'Reclamo alla Corte dei reclami penali del Tribunale penale federale']
+        }
+    }
+
+    if namespace['language'] not in all_section_markers:
+        message = f"This function is only implemented for the languages {list(all_section_markers.keys())} so far."
+        raise ValueError(message)
+
+    section_markers = all_section_markers[namespace['language']]
+    # combine multiple regex into one for each section due to performance reasons
+    section_markers = dict(map(lambda kv: (kv[0], '|'.join(kv[1])), section_markers.items()))
+
+    # normalize strings to avoid problems with umlauts
+    for section, regexes in section_markers.items():
+        section_markers[section] = unicodedata.normalize('NFC', regexes)
+
+    paragraphs = get_pdf_paragraphs(decision)
+    return associate_sections(paragraphs, section_markers, namespace)
+
+
 def get_paragraphs(divs):
     # """
     # Get Paragraphs in the decision


### PR DESCRIPTION
Added the section splitting for the following spider: CH_BSTG.

Results for DE language:
- Header: 4356 / 4356 (100.00%) 
- Facts:  3390 / 4356 (77.82%) 
- Considerations: 4298 / 4356 (98.67%) 
- Rulings:        4023 / 4356 (92.36%) 
- Footer: 3974 / 4356 (91.23%) 

Results for FR language:
- Header: 2970 / 2970 (100.00%) 
- Facts:  2913 / 2970 (98.08%) 
- Considerations: 2733 / 2970 (92.02%) 
- Rulings:        2661 / 2970 (89.60%) 
- Footer: 2775 / 2970 (93.43%) 

Results for IT language:
- Header: 1144 / 1144 (100.00%) 
- Facts:  1045 / 1144 (91.35%) 
- Considerations: 1004 / 1144 (87.76%) 
- Rulings:        1030 / 1144 (90.03%) 
- Footer: 1080 / 1144 (94.41%) 

Remarks:
- The URLs generated for the PDFs do not work anymore. They did work, a while ago, way before our presentations. Now, whenever I press on one of the [links](https://bstger.weblaw.ch/pdf/TPF-2009-125.pdf), I land on a page with ["404 Not Found"](https://bstger.weblaw.ch/pdf/TPF-2005-73.pdf)
- Related to the point above, I believe that the numbers in the results could be improved a little more, but since I can not check the PDFs anymore, this is all I got. I did check a bunch of decisions and they seem to be sectioned just fine
- There are a few sections missing in the decisions here and there
- There are also a few strange decisions that I did not take care of, that I ignored(random examples from [Entscheidsuche](https://entscheidsuche.ch/), as I can not open the PDFs' URLs anymore):
1.  [Example 1](https://entscheidsuche.ch/docs/CH_BSTG/CH_BSTG_001_TPF-2007-1_2007.pdf#view=FitH)
2.  [Example 2](https://entscheidsuche.ch/docs/CH_BSTG/CH_BSTG_001_TPF-2016-17_2016.pdf#view=FitH)
3.  [Example 3](https://entscheidsuche.ch/docs/CH_BSTG/CH_BSTG_001_TPF-2007-18_2007.pdf#view=FitH)