### PR TITLE
Section splitting for BL_Gerichte

### DIFF
--- a/scrc/preprocessors/extractors/section_splitter.py
+++ b/scrc/preprocessors/extractors/section_splitter.py
@@ -153,7 +153,7 @@ class SectionSplitter(AbstractExtractor):
         """Override method to handle section data and paragraph data individually"""
         # TODO consider removing the overriding function altogether with new db
         self.logger.debug(f"{self.logger_info['processing_one']} {series['file_name']}")
-        namespace = series[['date', 'html_url', 'pdf_url', 'id']].to_dict()
+        namespace = series[['date', 'html_url', 'pdf_url', 'court', 'id']].to_dict()
         namespace['language'] = Language(series['language'])
         data = self.get_required_data(series)
         assert data

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -115,7 +115,7 @@ def BL_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
     :param namespace:   the namespace containing some metadata of the court decision
     :return:            the sections dict (keys: section, values: list of paragraphs)
     """
-    #Regular expressions adapted to each court
+    #Regular expressions adapted to each court separately
     if namespace['court'] == 'BL_SG':
         all_section_markers = {
             Language.DE: {
@@ -165,17 +165,6 @@ def BL_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
                 Section.CONSIDERATIONS: [r'^(Aus den Erwägungen:)$', r'^(\s*[Ii]\s*n\s*E\s*r\s*w\s*ä\s*g\s*u\s*n\s*g\s*(\s*e n)*\s*:*\s*)$'],
                 Section.RULINGS: [r'^(D\s*e\s*m\s*g\s*e\s*m\s*ä\s*s\s*s\s*w\s*i\s*r\s*d\s*e\s*r\s*k\s*a\s*n\s*n\s*t\s*:*\s*)$', r'^(wird erkannt:)$', r'^(D\s*e\s*m\s*g\s*e\s*m\s*ä\s*s\s*s\s*w\s*i\s*r\s*d\s*v\s*e\s*r\s*f\s*ü\s*g\s*t\s*:\s*)$'],
                 Section.FOOTER: [r'^(Rechtsmittelbelehrung)$']
-            }
-        }
-    elif namespace['court'] == 'BL_XX':
-        print("I am a decision from BL_XX")
-        all_section_markers = {
-            Language.DE: {
-                Section.HEADER: [r'empty'],
-                Section.FACTS: [r'empty'],
-                Section.CONSIDERATIONS: [r'empty'],
-                Section.RULINGS: [r'empty'],
-                Section.FOOTER: [r'empty']
             }
         }
     else:

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -115,28 +115,71 @@ def BL_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
     :param namespace:   the namespace containing some metadata of the court decision
     :return:            the sections dict (keys: section, values: list of paragraphs)
     """
-    all_section_markers = {
-        Language.DE: {
-            Section.HEADER: [r'^((Beschluss|Entscheid|Urteil) des Kantonsgerichts Basel-Landschaft,)', r'^(Entscheid der Aufsichtsbehörde Schuldbetreibung und Konkurs)', r'^(Rechtsprechung Steuergericht Basel-Landschaft)$',
-                             r'^(Rechtsprechung des Kantonsgerichts)$', r'^((Entscheid|Beschluss) vom \d*\. (Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember) \d*)',
-                             r'^(Zwangsmassnahmengericht Basel-Landschaft www.bl.ch\/zmg)$', r'^(Rechtsprechung (Steuergericht|Enteignungsgericht))$', r'^(Entscheid des Steuer- und Enteignungsgerichts Basel-Landschaft,)$',
-                             r'12-09 Landabzug im Rahmen einer Baulandumlegung / Ermittlung der Entschädi', r'12-08 Strassenbeitrag / Sondervorteil aufgrund Randsteine, Entwässerung, Stras-',
-                             r'11-05 Enteignung nachbarrechtlicher Abwehransprüche/ Bindung an die Erwägun', r'12-07 Übereinstimmung einer im Strassenreglement aufgeführten Qualifikation einer '],
-            Section.FACTS: [r'^(Betreff)', r'^(Gegenstand)', r'^(betreffend)', r'^(Sachverhalt:*)', r'^(S a c h v e r h a l t:*)', r'^(IV-Stelle Basel-Landschaft, Hauptstrasse 109, 4102 Binningen,)',
-                            r'^(IV-Stelle Basel-Landschaft, Beschwerdegegnerin)', r'^(Verkehrswert einer Liegenschaft im Ausland)$', r'^(Öffentliche Arbeitslosenkasse Baselland)$', r'^(Aus dem Sachverhalt( Zusammenfassung)*:*)$'],
-            Section.CONSIDERATIONS: [r'^((Das|Die) (Kantonsgericht|Steuergericht) zieht\s*i\s*n\s*E\s*r\s*w\s*ä\s*g\s*u\s*n\s*g\s*:*\s*)$', r'^(E\s*r\s*w\s*ä\s*g\s*u\s*n\s*g\s*e\s*n\s*:*\s*)$',
-                                     r'^(Das Steuergericht zieht\s*in Erwägung\s*:)$', r'^((Die|Der) Präsident(in)* zieht\s*i\s*n\s*E\s*r\s*w\s*ä\s*g\s*u\s*n\s*g\s*:\s*)$',
-                                     r'Der Vizepräsident zieht i n E r w ä g u n g\s*:', r'^(Aus den Erwägungen\s*:*)$', r'^(\s*[Ii]\s*n\s*E\s*r\s*w\s*ä\s*g\s*u\s*n\s*g\s*(\s*e n)*\s*:*\s*)$',
-                                     r'Der (Vize-)*Präsident des Steuergerichts zieht in Erwägung\s*: ', r'^(In Erwägung(,)* dass(,|:)*)$',  r'^((I. )*Erwägungen:*\s*)$'
-                                     r'^(Der Präsident des Steuergerichts zieht\s*i\s*n\s*E\s*r\s*w\s*ä\s*g\s*u\s*n\s*g\s*:\s*)$',
-                                     r'Das Steuergericht zieht i\s*n E r w ä g u n g\s*: ', r'Das Kantonsgericht hat i n E r w ä g u n g ,',
-                                     r'Auszug aus den Erwägungen:', r'(Der|Die) Präsident(in)* hat\s*i\s*n\s*E\s&r\s*w\s*ä\s*g\s*u\s*n\s*g\s*,\s*'],
-            Section.RULINGS: [r'^(D\s*e\s*m\s*n\s*a\s*c\s*h\s*w\s*i\s*r\s*d\s*e\s*r\s*k\s*a\s*n\s*n\s*t\s*:*\s*)$', r'^(D\s*e\s*m\s*g\s*e\s*m\s*ä\s*s\s*s\s*w\s*i\s*r\s*d\s*e\s*r\s*k\s*a\s*n\s*n\s*t\s*:*\s*)$',
-                              r'^((Es)*\s*\s*w\s*i\s*r\s*d\s*e\s*r\s*k\s*a\s*n\s*n\s*t\s*:\s*)$', r'(Demgemäss|Demnach) erkennt das Steuergericht:', r'^(e\s*r\s*k\s*a\s*n\s*n\s*t\s*:\s*)$',
-                              r'^((Es wird)*\s*e\s*n\s*t\s*s\s*c\s*h\s*i\s*e\s*d\s*e\s*n\s*:\s*)$', r'\s*D\s*e\s*m\s*g\s*e\s*m\s*ä\s*s\s*s\s*w\s*i\s*r\s*d\s*b\s*e\s*s\s*c\s*h\s*l\s*o\s*s\s*s\s*e\s*n\s*:*\s*'],
-            Section.FOOTER: [r'^(Rechtsmittelbelehrung)$']
-         }
-    }
+    #Regular expressions adapted to each court
+    if namespace['court'] == 'BL_SG':
+        all_section_markers = {
+            Language.DE: {
+                Section.HEADER: [r'^(Rechtsprechung Steuergericht( Basel-Landschaft\s*)*)$', r'^((Entscheid|Beschluss) vom \d*\. (Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember) \d*)',
+                                 r'07-10(0|1) Abgrenzung Haupterwerb - Nebenerwerb', r'08-64 Verpflegungsmehrkosten', r'08-125 Liegenschaftsunterhalt', r'07-104 Begründungspflicht', r'07-025 Privater Schuldzinsabzug',
+                                 r'08-14(5|6) WIR-Geld', r'08-138 Aktienbewertung bei Ehegatten', r'07-057 Besteuerung eines ohne festen Wohnsitz im Ausland lebenden Ehegatten', r'06-16(7|8) Schneeballprinzip',
+                                 r'07-058 Besteuerung eines ohne festen Wohnsitz im Ausland lebenden Ehegatten', r'07-026 Privater Schuldzinsabzug', r'06-066 Ermittlung des Hauptsteuerdomizils',
+                                 r'08-126 Erbschaftssteuer bei Ausrichtung eines Legats, rechtliches Gehör'],
+                Section.FACTS: [r'^(Sachverhalt:*)$', r'^(Aus dem Sachverhalt( \(Zusammenfassung\))*:)$', r'^(S a c h v e r h a l t :)', r'^(Aus dem Sachverhalt \(gekürzt\):)$'],
+                Section.CONSIDERATIONS: [r'Aus den Erwägungen\s*:*', r'^(Erwägungen:*\s*)$', r'^(\s*[Ii]\s*n\s*E\s*r\s*w\s*ä\s*g\s*u\s*n\s*g\s*(\s*e n)*\s*:*\s*)$', r'^(Das Steuergericht zieht\s*i\s*n\s*E\s*r\s*w\s*ä\s*g\s*u\s*n\s*g\s*:*\s*)$',
+                                         r'Der Präsident des Steuergerichts zieht in Erwägung :'],
+                Section.RULINGS: [r'^(D\s*e\s*m\s*g\s*e\s*m\s*ä\s*s\s*s\s*w\s*i\s*r\s*d\s*e\s*r\s*k\s*a\s*n\s*n\s*t\s*:*\s*)$', r'(Demgemäss|Demnach) erkennt das Steuergericht:',  r'^(w\s*i\s*r\s*d\s*e\s*r\s*k\s*a\s*n\s*n\s*t\s*:\s*)$'],
+                Section.FOOTER: [r'^(Rechtsmittelbelehrung)$']
+            }
+        }
+    elif namespace['court'] == 'BL_ZMG':
+        all_section_markers = {
+            Language.DE: {
+                Section.HEADER: [r'^(Zwangsmassnahmengericht Basel-Landschaft www.bl.ch\/zmg)$', r'^(Entscheid des Zwangsmassnahmengerichts vom 13.09.2016 (350 16 419))'],
+                Section.FACTS: [r'^(Betreffend)', r'^(Sachverhalt)$'],
+                Section.CONSIDERATIONS: [r'^(In Erwägung(,)* dass(,|:)*)$', r'^((I. )*Erwägungen:*\s*)$'],
+                Section.RULINGS: [r'^(Es\swird\se\s*n\s*t\s*s\s*c\s*h\s*i\s*e\s*d\s*e\s*n\s*:)', r'^(wird\s*e\s*n\s*t\s*s\s*c\s*h\s*i\s*e\s*d\s*e\s*n\s*:)', r'^(e n t s c h i e d e n :)$'],
+                Section.FOOTER: [r'^(Rechtsmittelbelehrung)$']
+            }
+        }
+    elif namespace['court'] == 'BL_KG':
+        all_section_markers = {
+            Language.DE: {
+                Section.HEADER: [r'^((Beschluss|Entscheid|Urteil) des Kantonsgerichts Basel-Landschaft, )',  r'^(Rechtsprechung des Kantonsgerichts)$'],
+                Section.FACTS: [r'^(Betreff)', r'^(Gegenstand)', r'^(Sachverhalt:*)$'],
+                Section.CONSIDERATIONS: [r'^((Das|Die) (Kantonsgericht|Steuergericht) zieht\s*i\s*n\s*E\s*r\s*w\s*ä\s*g\s*u\s*n\s*g\s*:*\s*)$', r'^((Die|Der) Präsident(in)* zieht\s*i\s*n\s*E\s*r\s*w\s*ä\s*g\s*u\s*n\s*g\s*:\s*)$', r'^(In Erwägung(,)* dass(,|:)*)$',
+                                         r'^(Erwägungen\s*)$', r'^(In Erwägung(,)* dass(,|:)*)$', r'^(Auszug aus den Erwägungen:*)$', r'^(Aus den Erwägungen:*)$', r'^(Erwägung)$',
+                                         r'(Der|Die) Präsident(in)* hat\s*i\s*n\s*E\s&r\s*w\s*ä\s*g\s*u\s*n\s*g\s*,\s*', r'Das Kantonsgericht hat i n E r w ä g u n g ,'],
+                Section.RULINGS: [r'^(D\s*e\s*m\s*n\s*a\s*c\s*h\s*w\s*i\s*r\s*d\s*e\s*r\s*k\s*a\s*n\s*n\s*t\s*:*\s*)$', r'^(D\s*e\s*m\s*g\s*e\s*m\s*ä\s*s\s*s\s*w\s*i\s*r\s*d\s*e\s*r\s*k\s*a\s*n\s*n\s*t\s*:*\s*)$',
+                                  r'^((Es)*\s*w\s*i\s*r\s*d\s*e\s*r\s*k\s*a\s*n\s*n\s*t\s*:\s*)$', r'^(Demnach wird beschlossen:)$', r'^(Demgemäss wird v e r f ü g t:\s*)$',
+                                  r'^(Demgemäss wird b e s c h l o s s e n :)$', r'^(e\s*r\s*k\s*a\s*n\s*n\s*t\s*:\s*)$', r'://:'],
+                Section.FOOTER: [r'^(Rechtsmittelbelehrung)$']
+            }
+        }
+    elif namespace['court'] == 'BL_EG':
+        all_section_markers = {
+            Language.DE: {
+                Section.HEADER: [r'^(Rechtsprechung Enteignungsgericht)$', r'^(Entscheid des Steuer- und Enteignungsgerichts Basel-Landschaft,)$', r'12-09 Landabzug im Rahmen einer Baulandumlegung \/ Ermittlung der Entschädi',
+                                 r'11-05 Enteignung nachbarrechtlicher Abwehransprüche\/ Bindung an die Erwägun-', r'12-07 Übereinstimmung einer im Strassenreglement aufgeführten Qualifikation einer',
+                                 r'12-08 Strassenbeitrag \/ Sondervorteil aufgrund Randsteine, Entwässerung, Stras-'],
+                Section.FACTS: [r'^(Aus dem Sachverhalt:)$', r'^(Gegenstand)'],
+                Section.CONSIDERATIONS: [r'^(Aus den Erwägungen:)$', r'^(\s*[Ii]\s*n\s*E\s*r\s*w\s*ä\s*g\s*u\s*n\s*g\s*(\s*e n)*\s*:*\s*)$'],
+                Section.RULINGS: [r'^(D\s*e\s*m\s*g\s*e\s*m\s*ä\s*s\s*s\s*w\s*i\s*r\s*d\s*e\s*r\s*k\s*a\s*n\s*n\s*t\s*:*\s*)$', r'^(wird erkannt:)$', r'^(D\s*e\s*m\s*g\s*e\s*m\s*ä\s*s\s*s\s*w\s*i\s*r\s*d\s*v\s*e\s*r\s*f\s*ü\s*g\s*t\s*:\s*)$'],
+                Section.FOOTER: [r'^(Rechtsmittelbelehrung)$']
+            }
+        }
+    elif namespace['court'] == 'BL_XX':
+        print("I am a decision from BL_XX")
+        all_section_markers = {
+            Language.DE: {
+                Section.HEADER: [r'empty'],
+                Section.FACTS: [r'empty'],
+                Section.CONSIDERATIONS: [r'empty'],
+                Section.RULINGS: [r'empty'],
+                Section.FOOTER: [r'empty']
+            }
+        }
+    else:
+        message = f"({namespace['id']}): We got stuck at court {court}. Please check! "
 
     if namespace['html_url']:
         valid_namespace(namespace, all_section_markers)


### PR DESCRIPTION
Added the section splitting for the following spider: BL_Gerichte.

Results for DE language:
- Header: 6392 / 6399 (99.89%) 
- Facts:  6153 / 6399 (96.16%) 
- Considerations: 6219 / 6399 (97.19%) 
- Rulings:        5326 / 6399 (83.23%) 
- Footer: 46 / 6399 (0.72%)

Remarks:
- only a few have footer
- lots of them are lacking the section "Rulings"
- a few of them are missing one section, or sometimes two
- and for this spider, I found many different types of "formats":
1. [Format 1](https://www.baselland.ch/politik-und-behorden/gerichte/rechtsprechung/steuergericht/entscheide-des-steuergerichts-2018/entscheide-in-pdf/2018-03-23-stger-1.pdf/@@download/file/2018-03-23-stger-1.pdf)
2. [Format 2](https://www.baselland.ch/politik-und-behorden/gerichte/rechtsprechung/zwangsmassnahmengericht/2012/downloads/2012-03-09_1.pdf/@@download/file/2012-03-09_1.pdf)
3. [Format 3](https://www.baselland.ch/politik-und-behorden/gerichte/rechtsprechung/steuergericht/2012/downloads/510_12_21.pdf/@@download/file/510_12_21.pdf)
4. [Format 4](https://www.baselland.ch/politik-und-behorden/gerichte/rechtsprechung/enteignungsgericht/entscheide-chronologisch/downloads/11-005.pdf/@@download/file/11-005.pdf)

Here I made a list of decision I believe they are _unwanted_:
1. [Decision 1](https://www.baselland.ch/politik-und-behorden/gerichte/rechtsprechung/kantonsgericht/rechtsgebiet/invalidenversicherung/downloads/2017-07-27-sv-7.pdf/@@download/file/2017-07-27-sv-7.pdf)
2. [Decision 2](chung/kantonsgericht/rechtsgebiet/erwerbsersatz/downloads/2020-10-23_sv_1.pdf/@@download/file/2020-10-23_sv_1.pdf)
3. [Decision 3](https://www.baselland.ch/politik-und-behorden/gerichte/rechtsprechung/kantonsgericht/rechtsgebiet/invalidenversicherung/downloads/2019-02-13-sv-1.pdf/@@download/file/2019-02-13-sv-1.pdf)
4. [Decision 4](https://www.baselland.ch/politik-und-behorden/gerichte/rechtsprechung/kantonsgericht/rechtsgebiet/erwerbsersatz/downloads/2020-10-23_sv_3.pdf/@@download/file/2020-10-23_sv_3.pdf)
5. [Decision 5](https://www.baselland.ch/politik-und-behorden/gerichte/rechtsprechung/kantonsgericht/rechtsgebiet/familienzulagen/downloads/2018-09-27-sv-2.pdf/@@download/file/2018-09-27-sv-2.pdf)
6. [Decision 6](https://www.baselland.ch/politik-und-behorden/gerichte/rechtsprechung/kantonsgericht/rechtsgebiet/invalidenversicherung/downloads/2019-08-22-sv-5.pdf/@@download/file/2019-08-22-sv-5.pdf)
7. [Decision 7](https://www.baselland.ch/politik-und-behorden/gerichte/rechtsprechung/kantonsgericht/rechtsgebiet/arbeitslosenversicherung/downloads/2016-04-28-sv-3.pdf/@@download/file/2016-04-28-sv-3.pdf)
8. [Decision 8](https://www.baselland.ch/politik-und-behorden/gerichte/rechtsprechung/kantonsgericht/rechtsgebiet/invalidenversicherung/downloads/2019-09-19-sv-2.pdf/@@download/file/2019-09-19-sv-2.pdf)
9. [Decision 9](https://www.baselland.ch/politik-und-behorden/gerichte/rechtsprechung/kantonsgericht/rechtsgebiet/invalidenversicherung/downloads/2016-03-03-sv-2.pdf/@@download/file/2016-03-03-sv-2.pdf)