### PR TITLE
ju_gerichte judgment_extraction

### DIFF
--- a/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
@@ -127,6 +127,56 @@ def XX_SPIDER(rulings: str, namespace: dict) -> Optional[List[Judgment]]:
     # This is an example spider. Just copy this method and adjust the method name and the code to add your new spider.
     pass
 
+def JU_Gerichte(rulings: str, namespace: dict) -> Optional[List[Judgment]]:
+    """
+    Extract judgment outcomes from the rulings
+    :param rulings:     the string containing the rulings
+    :param namespace:   the namespace containing some metadata of the court decision
+    :return:            the list of judgments
+    """
+    def getJudgments(text: str, judgment_markers, debug=False) -> Optional[List[Judgment]]:
+        """
+        Get the judgment outcomes based on a regex dictionary for a given section string.
+        :param text:               the text string of the section, usually Section.RULINGS
+        :param judgment_markers:   the regex dicttionary for the different judgment outcomes
+        :param debug:              if set to True, prints debug output to console
+        :return:                   the list of judgment outcomes
+        """
+
+        judgments = []
+        for lang in judgment_markers:
+            for judg in judgment_markers[lang]:
+                for reg in (judgment_markers[lang])[judg]:
+                    matches = re.finditer(reg, text, re.MULTILINE)
+                    for num, match in enumerate(matches, start=1):
+                        from_, to_, match_text  = match.start(), match.end(), match.group()
+                        judgments.append(judg)
+                        if debug:
+                            print(f'{judg} ("{match.group()}") at {to_/len(text):.1%} of the section.')
+
+        return judgments
+
+    if namespace['language'] not in all_judgment_markers:
+        message = f"This function is only implemented for the languages {list(all_judgment_markers.keys())} so far."
+        raise ValueError(message)
+
+    # make sure we don't have any nasty unicode problems
+    rulings = clean_text(rulings)
+
+    judgments = getJudgments(rulings, namespace)
+
+    if not judgments:
+        message = f"Found no judgment for the rulings \"{rulings}\" in the case {namespace['html_url']}. Please check!"
+        raise ValueError(message)
+    elif len(judgments) > 1:
+        if Judgment.PARTIAL_APPROVAL in judgments:
+            # if partial_approval is found, it will find approval as well
+            judgments.discard(Judgment.APPROVAL)
+        if Judgment.PARTIAL_DISMISSAL in judgments:
+ # if partial_dismissal is found, it will find dismissal as well
+            judgments.discard(Judgment.DISMISSAL)
+    return [judgment.value for judgment in judgments]
+
 def BS_Omni(rulings: str, namespace: dict) -> Optional[List[Judgment]]:
     """
     Extract judgment outcomes from the rulings


### PR DESCRIPTION
Generating judgment extraction function for JU_GERICHTE.
It must be used with the new judgment markers the ones that are in this [PR](https://github.com/JoelNiklaus/SwissCourtRulingCorpus/pull/64)