### PR TITLE
Implements coverage verification, fixes Section_splitting & Judgment_outcome

### DIFF
--- a/scrc/analyses/coverage_verification.py
+++ b/scrc/analyses/coverage_verification.py
@@ -1,0 +1,52 @@
+
+from sqlite3 import Connection
+from symbol import stmt
+from scrc.preprocessors.abstract_preprocessor import AbstractPreprocessor
+from scrc.utils.log_utils import get_logger
+from scrc.utils.main_utils import get_config
+from sqlalchemy.sql.schema import Table, MetaData
+from sqlalchemy.sql import select, func
+
+
+
+
+class CoverageVerification(AbstractPreprocessor):
+    "Ouputs docx files of court rulings with highlighted paragraphs of each section recognized aswell as the sentence which indicated the ruling outcome"
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self.logger = get_logger(__name__)
+        self.decision = []
+        self.logger_info = {
+            'start': 'Started coverage verification',
+            'finished': 'Finished coverage verification',
+            'start_spider': 'Started coverage verification for spider',
+            'finish_spider': 'Finished coverage verification for spider',
+        }
+    
+    def start(self):
+        self.get_random_decisions()
+        
+        
+    def get_random_decisions(self):
+        engine = self.get_engine(self.db_scrc)
+        with engine.connect() as conn:
+            d = Table('decision', MetaData(), autoload_with = engine)
+            stmt = select(d.columns.decision_id).order_by(func.random()).limit(50)
+            result = conn.execute(stmt)
+            for res in result:
+                self.get_sections(res, d, conn, engine)
+                
+    def get_sections(self, decision_id: str, d_table: Table, conn: Connection, engine):
+        d = Table('decision', MetaData(), autoload_with = engine)
+        result = conn.execute(stmt)
+
+
+        
+        
+    
+        
+if __name__ == '__main__':
+    config = get_config()
+
+    coverage_verification = CoverageVerification(config)
+    coverage_verification.start()

--- a/scrc/analyses/coverage_verification.py
+++ b/scrc/analyses/coverage_verification.py
@@ -11,11 +11,11 @@ from docx.enum.text import WD_COLOR_INDEX
 
 
 class Color(Enum):
-    HEADER = WD_COLOR_INDEX.YELLOW
-    FACTS = WD_COLOR_INDEX.GREEN
-    CONSIDERATIONS = WD_COLOR_INDEX.BLUE
-    RULINGS = WD_COLOR_INDEX.RED
-    FOOTER = WD_COLOR_INDEX.VIOLET
+    HEADER = 7
+    FACTS = 8
+    CONSIDERATIONS = 10
+    RULINGS = 16
+    FOOTER = 3
 
 
 class CoverageVerification(AbstractPreprocessor):
@@ -36,24 +36,29 @@ class CoverageVerification(AbstractPreprocessor):
         document = Document()
         self.init_engine(document)
         
+        
     def init_engine(self, document):
         spider_list, message = self.compute_remaining_spiders(self.processed_file_path)
+        self.logger.info(message)
         engine = self.get_engine(self.db_scrc)
         with engine.connect() as conn:
-            for spider in spider_list:  
+            for spider in spider_list:
                 for x in range(0, 20):
-                    self.get_random_decision(conn, document, spider)
+                    self.get_random_decision(conn, document, spider, 0)
                 document.save(self.get_path(spider))     
 
             
-    def get_random_decision(self, conn: Connection, document, spider):
+    def get_random_decision(self, conn: Connection, document, spider, try_count):
         result = conn.execute(self.random_decision_query(spider))
         for res in result:
             section_dict = self.get_sections(res, conn)
-            if not self.valid_decision(section_dict['sections']):
-                self.get_random_decision(conn, document, spider)
+            if not self.valid_decision(section_dict['sections']) and try_count <= 5:
+                try_count += 1
+                self.get_random_decision(conn, document, spider, try_count)
+            elif try_count > 5:
+                return
             else: 
-                self.append_to_doc(section_dict, document)
+                self.append_to_doc(section_dict, document, conn)
                 
     def get_sections(self, result: str, conn: Connection,):
         section_dict = {'sections': {}, 'id': result[0]}
@@ -69,14 +74,28 @@ class CoverageVerification(AbstractPreprocessor):
                 count += 1
         return count > 2
         
-    def append_to_doc(self, section_dict: dict, document: Document):
+    def append_to_doc(self, section_dict: dict, document: Document, conn: Connection):
         document.add_paragraph(str(section_dict['id']))
         sorted_list = sorted(list(section_dict['sections'].items()), key=lambda x: Section[x[0]].value)
+        ruling = self.get_ruling_outcome(str(section_dict['id']), conn)
         for element in sorted_list:
             p = document.add_paragraph()
-            r = p.add_run(element[1]).font
+            r = p.add_run(f"{element[0]}: {element[1]}").font
             r.highlight_color = Color[element[0]].value
+            if element[0] == 'RULINGS' and ruling:
+                p = document.add_paragraph()
+                r = p.add_run(ruling.text).bold = True         
         return document 
+    
+    def get_ruling_outcome(self, decision_id: str, conn: Connection):
+        return conn.execute(self.ruling_outcome_query(decision_id)).fetchone()
+        
+    
+    def ruling_outcome_query(self, decision_id: str):
+        return (f"SELECT * FROM judgment "
+                f"INNER JOIN judgment_map ON judgment.judgment_id = judgment_map.judgment_id "
+                f"INNER JOIN decision ON judgment_map.decision_id = decision.decision_id "
+                f"WHERE decision.decision_id = '{decision_id}'")
     
     def append_paragraph(self, section_text: str, section_type, document: Document):
         p = document.add_paragraph()

--- a/scrc/analyses/coverage_verification.py
+++ b/scrc/analyses/coverage_verification.py
@@ -7,7 +7,6 @@ from scrc.utils.log_utils import get_logger
 from scrc.utils.main_utils import get_config
 from scrc.enums.section import Section
 from docx import Document
-from docx.enum.text import WD_COLOR_INDEX
 
 
 class Color(Enum):
@@ -19,7 +18,8 @@ class Color(Enum):
 
 
 class CoverageVerification(AbstractPreprocessor):
-    "Ouputs docx files of court rulings with highlighted paragraphs of each section recognized aswell as the sentence which indicated the ruling outcome"
+    """Ouputs docx files of court rulings with highlighted paragraphs of each section recognized aswell as the sentence which indicated the ruling outcome. 
+    To run simply execute python -m scrc.analyses.coverage_verification and make sure coverage_verification.txt exists."""
     def __init__(self, config: dict):
         super().__init__(config)
         self.logger = get_logger(__name__)

--- a/scrc/analyses/coverage_verification.py
+++ b/scrc/analyses/coverage_verification.py
@@ -45,7 +45,10 @@ class CoverageVerification(AbstractPreprocessor):
             for spider in spider_list:
                 for x in range(0, 20):
                     self.get_random_decision(conn, document, spider, 0)
-                document.save(self.get_path(spider))     
+                document.save(self.get_path(spider))
+                self.logger.info(self.logger_info['finish_spider'] + ' ' + spider)
+                self.mark_as_processed(self.processed_file_path, spider)
+            self.logger.info(self.logger_info['finished'])
 
             
     def get_random_decision(self, conn: Connection, document, spider, try_count):

--- a/scrc/enums/section.py
+++ b/scrc/enums/section.py
@@ -14,3 +14,8 @@ class Section(Enum):
     @classmethod
     def without_facts(cls):
         return cls.HEADER, cls.HEADER,cls.CONSIDERATIONS, cls.RULINGS, cls.FOOTER
+    
+    @classmethod
+    def without_topic(cls):
+        return cls.FULLTEXT, cls.HEADER, cls.FACTS, cls.CONSIDERATIONS, cls.RULINGS, cls.FOOTER
+    

--- a/scrc/enums/section.py
+++ b/scrc/enums/section.py
@@ -11,11 +11,5 @@ class Section(Enum):
     FOOTER = 7
 
 
-    @classmethod
-    def without_facts(cls):
-        return cls.HEADER, cls.HEADER,cls.CONSIDERATIONS, cls.RULINGS, cls.FOOTER
-    
-    @classmethod
-    def without_topic(cls):
-        return cls.FULLTEXT, cls.HEADER, cls.FACTS, cls.CONSIDERATIONS, cls.RULINGS, cls.FOOTER
+
     

--- a/scrc/preprocessors/abstract_preprocessor.py
+++ b/scrc/preprocessors/abstract_preprocessor.py
@@ -123,7 +123,7 @@ class AbstractPreprocessor:
     @staticmethod
     def mark_as_processed(processed_file_path: Path, part: str) -> None:
         with processed_file_path.open("a") as f:
-            f.write(f"{part} + \n")
+            f.write(f"{part}\n")
 
     def compute_remaining_spiders(self, processed_file_path: Path):
         """This can be used to save progress in between runs in case something fails"""

--- a/scrc/preprocessors/extractors/judgment_extractor.py
+++ b/scrc/preprocessors/extractors/judgment_extractor.py
@@ -65,7 +65,7 @@ class JudgmentExtractor(AbstractExtractor):
         return self.select(engine,
                            f"section {join_decision_and_language_on_parameter('decision_id', 'section.decision_id')} {join_file_on_decision()}",
                            f"section.decision_id, section_text, '{spider}' as spider, iso_code as language, html_url",
-                           where=f"section.section_type_id = 5 AND section.decision_id IN {where_string_spider('decision_id', spider)} {only_given_decision_ids_string}",
+                           where=f"section.section_type_id = 6 AND section.decision_id IN {where_string_spider('decision_id', spider)} {only_given_decision_ids_string}",
                            chunksize=self.chunksize)
 
     def save_data_to_database(self, df: pd.DataFrame, engine: Engine):

--- a/scrc/preprocessors/extractors/judgment_pattern_extractor.py
+++ b/scrc/preprocessors/extractors/judgment_pattern_extractor.py
@@ -13,6 +13,7 @@ from sqlalchemy.engine.base import Engine
 from scrc.enums.judgment import Judgment
 from scrc.enums.language import Language
 from nltk import ngrams
+from scrc.enums.section import Section
 
 
 from scrc.preprocessors.extractors.abstract_extractor import AbstractExtractor
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
 
 class JudgmentExtractor(AbstractExtractor):
     """
-    Extracts the judgments from the rulings section. This represents the judgment extraction task.
+    Extracts the pattern of ruling section indicators for a given court. Only outputs the coverage if a command line argument it given.
     """
 
     def __init__(self, config: dict):
@@ -53,11 +54,12 @@ class JudgmentExtractor(AbstractExtractor):
         return f"spider='{spider}' AND rulings IS NOT NULL AND rulings <> ''"
     
     def get_coverage(self, spider: str):
-            with self.get_engine(self.db_scrc).connect() as conn:
-                total_judgments = conn.execute(get_total_judgments(spider)).fetchone()
-                coverage_result = conn.execute(get_judgment_query(spider)).fetchone()
-                coverage =  round(coverage_result[0] / total_judgments[0]  * 100, 2)
-                self.logger.info(f'{spider}: Found judgment outcome for {coverage}% of the rulings')
+        ruling_id = Section.RULINGS.value
+        with self.get_engine(self.db_scrc).connect() as conn:
+            total_judgments = conn.execute(get_total_judgments(spider, ruling_id)).fetchone()
+            coverage_result = conn.execute(get_judgment_query(spider, ruling_id)).fetchone()
+            coverage =  round(coverage_result[0] / total_judgments[0]  * 100, 2)
+            self.logger.info(f'{spider}: Found judgment outcome for {coverage}% of the rulings')
     
 
         

--- a/scrc/preprocessors/extractors/pattern_extractor.py
+++ b/scrc/preprocessors/extractors/pattern_extractor.py
@@ -39,7 +39,6 @@ class PatternExtractor(AbstractExtractor):
         super().__init__(config, function_name="pattern_extracting_functions", col_name='')
         self.logger = get_logger(__name__)
         self.columns = ['keyword', 'totalcount', 'example']
-        self.test = Language.DE
         self.df = pd.DataFrame(columns=self.columns)
         self.language = {}
         self.currentLanguage = ''

--- a/scrc/preprocessors/extractors/section_splitter.py
+++ b/scrc/preprocessors/extractors/section_splitter.py
@@ -92,7 +92,7 @@ class SectionSplitter(AbstractExtractor):
                 return series[section]
             return '\n'.join(series[section])
 
-        for section in Section.without_topic():
+        for section in Section:
             df[section.name] = df['sections'].apply(lambda row: get_section_from_df(row, section))
             df[section.name+'_spacy'] = [len(result) for result in spacy_tokenizer.pipe(df[section.name], batch_size=100)]
             df[section.name+'_bert'] = [len(input_id) for input_id in bert_tokenizer(df[section.name].tolist()).input_ids]   

--- a/scrc/preprocessors/extractors/section_splitter.py
+++ b/scrc/preprocessors/extractors/section_splitter.py
@@ -92,9 +92,7 @@ class SectionSplitter(AbstractExtractor):
                 return series[section]
             return '\n'.join(series[section])
 
-        for section in Section:
-            if section == Section.FACTS:
-                print('')
+        for section in Section.without_topic():
             df[section.name] = df['sections'].apply(lambda row: get_section_from_df(row, section))
             df[section.name+'_spacy'] = [len(result) for result in spacy_tokenizer.pipe(df[section.name], batch_size=100)]
             df[section.name+'_bert'] = [len(input_id) for input_id in bert_tokenizer(df[section.name].tolist()).input_ids]   

--- a/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
@@ -160,6 +160,26 @@ def ZH_Baurekurs(rulings: str, namespace: dict) -> Optional[List[Judgment]]:
     
     return judgments
 
+def BS_Omni(rulings: str, namespace: dict) -> Optional[List[Judgment]]:
+    """
+    Extract judgment outcomes from the rulings
+    :param rulings:     the string containing the rulings
+    :param namespace:   the namespace containing some metadata of the court decision
+    :return:            the list of judgments
+    """
+
+    if namespace['language'] not in all_judgment_markers:
+        message = f"This function is only implemented for the languages {list(all_judgment_markers.keys())} so far."
+        raise ValueError(message)
+
+    # make sure we don't have any nasty unicode problems
+    rulings = clean_text(rulings)
+
+    judgments = unnumbered_rulings(rulings, namespace)
+
+    judgments = verify_judgments(judgments, rulings, namespace)
+    
+    return judgments
 def LU_Gerichte(rulings: str, namespace: dict) -> Optional[List[Judgment]]:
     """
     Extract judgment outcomes from the rulings

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -565,7 +565,7 @@ def BS_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
             Section.CONSIDERATIONS: [r'^Begründung:\s*$', r'Erwägung(en)?:?\s*$', r'^Entscheidungsgründe$',
                                      r'[iI]n Erwägung[:,]?\s*$'],
             Section.RULINGS: [r'Demgemäss erkennt d[\w]{2}', r'erkennt d[\w]{2} [A-Z]\w+:',
-                              r'Appellationsgericht (\w+ )?(\(\w+\) )?erkennt', r'^und erkennt:$', r'erkennt:\s*$'],
+                              r'Appellationsgericht (\w+ )?(\(\w+\) )?erkennt', r'^und erkennt:$', r'erkennt:\s*$', 'Demnach wird erkannt:'],
             Section.FOOTER: [r'^Rechtsmittelbelehrung$',
                              r'AUFSICHTSKOMMISSION', r'APPELLATIONSGERICHT']
         }

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -62,14 +62,12 @@ def XX_SPIDER(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optio
 def GE_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     all_section_markers = {
         Language.FR: {
-            Section.HEADER: [],
             Section.FACTS: [r'EN FAIT', r'en fait'],
             Section.CONSIDERATIONS: [r'EN DROIT', 'en droit'],
             Section.RULINGS: [r'PAR CES MOTIFS', r'LA CHAMBRE ADMINISTRATIVE'],
             Section.FOOTER: [r'La [g,G]reffière', r'la [G,g]reffière', r'Siégeant', r'Voie de recours', r'Le recours doit être', r'Le [G,g]reffier', r'Le [P,p]résident']
         },
         Language.DE: {
-            Section.HEADER: [],
             Section.FACTS: [r'Tatbestand', r'Sachverhalt'],
             Section.CONSIDERATIONS: [r"Erwägung"],
             Section.RULINGS: [r"Demnach erkennt", r"Demnach beschliesst", r"Demnach wird beschlossen",
@@ -193,7 +191,6 @@ def BE_Steuerrekurs(decision: Union[bs4.BeautifulSoup, str], namespace: dict) ->
 def GL_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [],
             Section.FACTS: [r'in Sachen', r'Sachverhalt'],
             Section.CONSIDERATIONS: [r'Erwägung', r'Erwägungen', r'Betracht:?$'],
             Section.RULINGS: [r'[D,d]emgemäss erkennt', r'erkennt sodann', r'Gericht[\s]*erkennt', r'Gericht beschliesst', r'zieht in Betracht', r'verfügt:?$', r'[D,d]emgemäss beschliesst', r'beschliesst:?$', r'erkennt:?$'],
@@ -212,7 +209,6 @@ def GL_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
 def BL_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [],
             Section.FACTS: [r'Sachverhalt'],
             Section.CONSIDERATIONS: [r'zieht i n E r w ä g u n g', r'Erwägungen', r'in Erwägung:'],
             Section.RULINGS: [r'Demgemäss wird e r k a n n t', r'Demgemäss w i r d e r k a n n t', r'Demnach wird erkannt', r'Demgemäss wird erkannt', r'Demnach erkennt das Steuergericht:', r'Demgemäss erkennt das Steuergericht:', r'wird erkannt:', r'Es wird erkannt:'],
@@ -231,7 +227,6 @@ def BL_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
 def AG_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [],
             Section.FACTS: [ r'^Sachverhalt', r'entnimmt den Akten:'],
             Section.CONSIDERATIONS: [r'in Erwägung:', r'Aus den Erwägungen', r'^Erwägungen$'],
             Section.RULINGS: [r'erkennt:?$', r'beschliesst:?$', r'entscheidet:?$'],
@@ -250,7 +245,6 @@ def AG_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
 def AG_Weitere(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [],
             Section.FACTS: [ r'^Sachverhalt', r'entnimmt den Akten:'],
             Section.CONSIDERATIONS: [r'in Erwägung:', r'Aus den Erwägungen'],
             Section.RULINGS: [r'erkennt:?$', r'beschliesst:?$', r'entscheidet:?$'],
@@ -269,14 +263,12 @@ def AG_Weitere(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opti
 def CH_WEKO(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [],
             Section.FACTS: [r'Sachverhalt$', r'in Sachen$', r'Ausgangslage$'],
             Section.CONSIDERATIONS: [r'Erwägungen$'],
             Section.RULINGS: [r'Dispositiv$', r'verfügt die WEKO', r'^[1-9] Ergebnis$', r'^[A-Z] Schlussfolgerungen$'],
             Section.FOOTER: [r'^Rechtsmittelbelehrung:?$']
         },
         Language.FR: {
-            Section.HEADER: [],
             Section.FACTS: [r'Etat de fait$', r'in Sachen$'],
             Section.CONSIDERATIONS: [r'Considérants$', r'CONSIDERANTS$'],
             Section.RULINGS: [r'Dispositif$', r'DISPOSITIF$'],
@@ -352,22 +344,10 @@ def TI_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
             Section.FOOTER: [r'Per il Tribunale cantonale delle assicurazioni', r'Il presidente La segretaria', r'Per il Tribunale cantonale amministrativo', r'Per la seconda Camera civile del Tribunale d’appello', r'Il presidente La vicecancelliera']
         },
         Language.EN: {
-            Section.FACTS: [],
-            Section.CONSIDERATIONS: [],
-            Section.RULINGS: [],
-            Section.FOOTER: []
         },
         Language.FR: {
-            Section.FACTS: [],
-            Section.CONSIDERATIONS: [],
-            Section.RULINGS: [],
-            Section.FOOTER: []
         },
         Language.DE: {
-            Section.FACTS: [],
-            Section.CONSIDERATIONS: [],
-            Section.RULINGS: [],
-            Section.FOOTER: []
         }
         
     }
@@ -513,7 +493,6 @@ def GR_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
     """
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [],
             Section.FACTS: [r'Sachverhalt:?$', r'betreffend\s*\w*$' r'hat sich ergeben:?', r'in Sachen$'],
             Section.CONSIDERATIONS: [r'Erwägungen:?$', r'zieht in Erwägung:?$', r'In Erwägung,'],
             Section.RULINGS: [r'^Demnach erkennt', r'wird erkannt:?$', r'^erkannt:?$', r'^Demnach verfügt', r'^verfügt:$', r'^erkannt :$', r'^verfügt :$', r'wird verfügt:$' ],
@@ -614,10 +593,9 @@ def SZ_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
     # (?:C|c) is much faster for case insensitivity than [Cc] or (?i)c
     all_section_markers = {
         Language.DE: {
-            Section.FACTS: [r'no fact section'],
-            Section.CONSIDERATIONS: [r'nachdem sich ergeben', r'nachdem sich ergeben und in Erwägung:', 'in Erwägung'],
             Section.RULINGS: [r'^erkennt[:]?$', r'^beschlossen[:]?$', r'^verfügt[:]?$', r'^erkannt[:]?$',
                               r'erkannt und beschlossen[:]?$', r'beschlossen und erkannt[:]?$'],
+            Section.CONSIDERATIONS: [r'nachdem sich ergeben', r'nachdem sich ergeben und in Erwägung:', 'in Erwägung'],
             Section.FOOTER: [r'^Namens', r'^Versand']
         }
     }
@@ -1159,7 +1137,6 @@ def SG_Publikationen(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -
 def SG_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [],
             Section.FACTS: [r'Sachverhalt:?$', r'in Sachen$', r'Das Verwaltungsgericht stellt fest:', r'hat das Verwaltungsgericht festgestellt:'],
             Section.CONSIDERATIONS: [r'^Erwägungen:?$', r'^Erwägung$', r'Darüber wird in Erwägung gezogen:', r'Darüber zieht das Verwaltungsgericht in Erwägung:', r'Aus den Erwägungen:', r'hat das Versicherungsgericht in Erwägung gezogen:', r'Der Abteilungspräsident erwägt:', r'in Erwägung gezogen:'],
             Section.RULINGS: [r'^Entscheid:?$', r'^entschieden:?$', r'^erkannt:?$', r'zu Recht erkannt:', r'zu Recht:$', r'zu Recht erkannt:$', r'^beschlossen$', r'festgestellt und erkannt:?$', r'verfügt:$', r'beschlossen und erkannt:?$', r'beschlossen:$', r'Demgemäss hat das Versicherungsgericht entschieden:' ],
@@ -1179,7 +1156,7 @@ def SG_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
 
 
 def associate_sections(paragraphs: List[str], section_markers, namespace: dict,
-                       sections: List[Section] = list(Section.without_topic()), current_section = Section.HEADER):
+                       sections: List[Section] = list(Section), current_section = Section.HEADER):
     """
     Associate sections to paragraphs
     :param paragraphs:      list of paragraphs
@@ -1188,6 +1165,7 @@ def associate_sections(paragraphs: List[str], section_markers, namespace: dict,
     :param sections:        if some sections are not present in the court, pass a list with the missing section excluded
     """
     paragraphs_by_section = {section: [] for section in sections}
+    # sections = determine_sections(section_markers, sections)
     for paragraph in paragraphs:
         # update the current section if a marker of a different section matched
         current_section = update_section(
@@ -1211,9 +1189,6 @@ def associate_sections(paragraphs: List[str], section_markers, namespace: dict,
     return paragraphs_by_section
 
 
-
-
-
 def update_section(current_section: Section, paragraph: str, section_markers, sections: List[Section]) -> Section:
     """
     Update the current section if it changed
@@ -1223,19 +1198,19 @@ def update_section(current_section: Section, paragraph: str, section_markers, se
     :param sections:        if some sections are not present in the court, pass a list with the missing section excluded
     :return:                the updated section
     """
+    sections = sorted([Section.HEADER] + list(section_markers), key=lambda x: x.value)
     paragraph = unicodedata.normalize(
         'NFC', paragraph)  # if we don't do this, we get weird matching behaviour
-    if current_section == Section.FOOTER:
+    if sections.index(current_section) == len(sections) - 1:
         return current_section  # we made it to the end, hooray!
-    next_section_index = sections.index(current_section) + 1
+    index = sections.index(current_section) + 1
     # consider all following sections
-    next_sections = sections[next_section_index:]
+    next_sections = sections[index:]
     for next_section in next_sections:
         marker = section_markers[next_section]
         if re.search(marker, paragraph):
             return next_section  # change to the next section
-    return current_section  # stay at the old section
-
+    return current_section# stay at the old section
 
 
 def CH_BGE(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
@@ -1278,8 +1253,6 @@ def CH_BGE(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional
 def AI_Aktuell(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [],
-            Section.FACTS: [r'no facts section'],
             Section.CONSIDERATIONS: [r'^Erwägungen:?$'],
             Section.RULINGS: [r'no ruling section'],
             Section.FOOTER: [r'^Rechtsmittelbelehrung']
@@ -1297,8 +1270,6 @@ def AI_Aktuell(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opti
 def AI_Bericht(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [],
-            Section.FACTS: [r'no facts section'],
             Section.CONSIDERATIONS: [r'^Erwägungen:?$', r'Aus den Erwägungen der Standeskommission:'],
             Section.RULINGS: [r'no ruling section'],
             Section.FOOTER: [r'^Rechtsmittelbelehrung']
@@ -1316,7 +1287,6 @@ def AI_Bericht(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opti
 def AR_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [],
             Section.FACTS: [r'^Sachverhalt:?$'],
             Section.CONSIDERATIONS: [r'^Erwägungen:?$', r'Aus den Erwägungen:'],
             Section.RULINGS: [r'erkennt das Obergericht:', r'erkennt:?$', r'beschliesst:?$', r'beschliesst das Obergericht:',],
@@ -1704,8 +1674,6 @@ def CH_BPatG(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Option
     """
     all_section_markers = {
         Language.DE: {
-            # Section.FACTS: [], # no facts in this court
-            Section.FACTS: [],
             Section.CONSIDERATIONS: [
                 r'^(?:Das Bundespatentgericht|(?:Der|Das) Präsident|Die Gerichtsleitung|Das Gericht|Der (?:Einzelrichter|Instruktionsrichter))' \
                 r' zieht in Erwägung(?:,|:)',
@@ -1725,8 +1693,6 @@ def CH_BPatG(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Option
             Section.FOOTER: [r'Voies de droit:']
         },
         Language.IT: {
-            Section.FACTS: [],
-            # Section.FACTS: [], # no facts in this court
             Section.CONSIDERATIONS: [r'Considerando in fatto e in diritto:'],
             Section.RULINGS: [r'Per questi motivi, il giudice unico pronuncia:'],
             Section.FOOTER: [r'Rimedi giuridici:']

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -1179,7 +1179,7 @@ def SG_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
 
 
 def associate_sections(paragraphs: List[str], section_markers, namespace: dict,
-                       sections: List[Section] = list(Section), current_section = Section.HEADER):
+                       sections: List[Section] = list(Section.without_topic()), current_section = Section.HEADER):
     """
     Associate sections to paragraphs
     :param paragraphs:      list of paragraphs

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -1165,7 +1165,6 @@ def associate_sections(paragraphs: List[str], section_markers, namespace: dict,
     :param sections:        if some sections are not present in the court, pass a list with the missing section excluded
     """
     paragraphs_by_section = {section: [] for section in sections}
-    # sections = determine_sections(section_markers, sections)
     for paragraph in paragraphs:
         # update the current section if a marker of a different section matched
         current_section = update_section(

--- a/scrc/preprocessors/text_to_database.py
+++ b/scrc/preprocessors/text_to_database.py
@@ -27,6 +27,8 @@ from scrc.utils.log_utils import get_logger
 from scrc.utils.main_utils import get_config
 from scrc.utils.sql_select_utils import join_decision_and_language_on_parameter, save_from_text_to_database, \
     where_string_spider
+    
+MIN_TEXT_LENGTH = 1000
 
 # TODO if we need to extract data from html with difficult structure such as tables consider using: https://pypi.org/project/inscriptis/
 
@@ -89,7 +91,7 @@ class TextToDatabase(AbstractPreprocessor):
         return all_processed_files
     
     def filter_by_text_length(self, spider_dict_list: dict):
-        filtered = [x for x in spider_dict_list if (len(x['pdf_raw']) > 1000 or len(x['html_raw']) > 1000)]
+        filtered = [x for x in spider_dict_list if (len(x['pdf_raw']) > MIN_TEXT_LENGTH or len(x['html_raw']) > MIN_TEXT_LENGTH)]
         return filtered
                 
 
@@ -97,8 +99,8 @@ class TextToDatabase(AbstractPreprocessor):
         """ Builds a dataset for a spider """
         spider_dir = self.spiders_dir / spider
         self.logger.info(f"Building spider dataset for {spider}")
-        # spider_dict_list = self.filter_by_text_length(self.build_spider_dict_list(spider_dir, spider))
-        spider_dict_list = self.build_spider_dict_list(spider_dir, spider)
+        spider_dict_list = self.filter_by_text_length(self.build_spider_dict_list(spider_dir, spider))
+        # spider_dict_list = self.build_spider_dict_list(spider_dir, spider)
 
         self.logger.info("Building pandas DataFrame from list of dicts")
         df = pd.DataFrame(spider_dict_list)

--- a/scrc/preprocessors/text_to_database.py
+++ b/scrc/preprocessors/text_to_database.py
@@ -89,7 +89,7 @@ class TextToDatabase(AbstractPreprocessor):
         return all_processed_files
     
     def filter_by_text_length(self, spider_dict_list: dict):
-        filtered = [x for x in spider_dict_list if (len(x['pdf_raw']) > 500 or len(x['html_raw']) > 500)]
+        filtered = [x for x in spider_dict_list if (len(x['pdf_raw']) > 1000 or len(x['html_raw']) > 1000)]
         return filtered
                 
 
@@ -97,6 +97,7 @@ class TextToDatabase(AbstractPreprocessor):
         """ Builds a dataset for a spider """
         spider_dir = self.spiders_dir / spider
         self.logger.info(f"Building spider dataset for {spider}")
+        # spider_dict_list = self.filter_by_text_length(self.build_spider_dict_list(spider_dir, spider))
         spider_dict_list = self.build_spider_dict_list(spider_dir, spider)
 
         self.logger.info("Building pandas DataFrame from list of dicts")

--- a/scrc/utils/sql_select_utils.py
+++ b/scrc/utils/sql_select_utils.py
@@ -10,6 +10,7 @@ from sqlalchemy.sql.schema import MetaData, Table
 from transformers.file_utils import add_code_sample_docstrings
 from scrc.enums.cantons import Canton
 from scrc.enums.chamber import Chamber
+from scrc.enums.section import Section
 
 if TYPE_CHECKING:
     from sqlalchemy.engine.base import Engine
@@ -43,7 +44,7 @@ def get_total_decisions(spider: str, language: int):
         f"WHERE spider.name = '{spider}' "
         f"AND language.language_id = {language} ")
     
-def get_judgment_query(spider):
+def get_judgment_query(spider, ruling_id):
     return (f"SELECT count(*) FROM section s "
             f"LEFT JOIN decision ON decision.decision_id = s.decision_id "
             f"LEFT JOIN judgment_map j "
@@ -53,10 +54,10 @@ def get_judgment_query(spider):
             f"WHERE spider.name = '{spider}' "
             f"AND section_text != '{{}}' "
             f"AND section_text != '' "
-            f"AND s.section_type_id = 5 "
+            f"AND s.section_type_id = {ruling_id} "
             f"AND j.judgment_id IS NOT NULL")
 
-def get_total_judgments(spider):
+def get_total_judgments(spider, ruling_id):
     return (f"SELECT count(*) FROM section s "
         f"LEFT JOIN decision ON decision.decision_id = s.decision_id "
         f"LEFT JOIN judgment_map j "
@@ -66,7 +67,7 @@ def get_total_judgments(spider):
         f"WHERE spider.name = '{spider}' "
         f"AND section_text != '{{}}' "
         f"AND section_text != '' "
-        f"AND s.section_type_id = 5 ")
+        f"AND s.section_type_id = {ruling_id} ")
 
 
 def join_decision_on_parameter(decision_field: str, target_table_and_field: str) -> str:


### PR DESCRIPTION
- Implements coverage verification for section_splitting & judgment_outcome
- Fixes section_splitting & judgment_outcome as it was bugged by the introduction of the new topic section
- Now returns empty list if a specific section was not defined in the section_splitting_function. This means that there is no need to define all sections sections anymore if some sections do not exist.
- Needed to add seperate judgment_extraction function for BS_Omni since it is of unnumbered structure. All unnumbered courts need not to run the defaullt (XX_Spider) function. 