### PR TITLE
Bugfixes & section_splitter improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,16 @@ Sometimes ``pip install`` says that the requirement is already satisfied. If the
 try ``python -m pip install ...``.
 
 Dask does not work with csv files containing new lines inside fields because it cannot process csv chunks
+
+## useful DB queries
+
+Amount of approvals for a specific court:
+SELECT count(*) FROM judgment
+            LEFT JOIN judgment_map ON judgment_map.judgment_id = judgment.judgment_id
+            LEFT JOIN decision ON decision.decision_id = judgment_map.decision_id
+            LEFT JOIN chamber ON chamber.chamber_id = decision.chamber_id
+            LEFT JOIN spider ON spider.spider_id = chamber.spider_id
+            WHERE spider.name = 'BS_Omni'
+            AND judgment.judgment_id = 1
+
+

--- a/scrc/analyses/coverage_verification.py
+++ b/scrc/analyses/coverage_verification.py
@@ -22,7 +22,9 @@ class CoverageVerification(AbstractPreprocessor):
     """Ouputs docx files of court rulings with highlighted paragraphs of each section recognized aswell as the ruling outcome to data/verification folder. 
     To run simply remove your desired spider from coverage_verification.txt and run:
     
-    python -m scrc.analyses.coverage_verification | python -m scrc.analyses.coverage_verification 1 (for rulings only)"""
+    python -m scrc.analyses.coverage_verification | python -m scrc.analyses.coverage_verification 1 (for rulings only)
+    
+    If you wish to increase the outputted document size, change the range in line 56 to a higher number."""
     
     def __init__(self, config: dict):
         super().__init__(config)
@@ -51,7 +53,7 @@ class CoverageVerification(AbstractPreprocessor):
     def write_document(self, spider, conn: Connection):
         document = Document()
         decision_list = []
-        for x in range(0, 40):  
+        for x in range(0, 45):  
             result = self.get_valid_decision(conn, spider, decision_list)
             self.write_to_doc(document, result, x)
         document.save(self.get_path(spider))

--- a/scrc/analyses/coverage_verification.py
+++ b/scrc/analyses/coverage_verification.py
@@ -20,11 +20,9 @@ class Color(Enum):
 
 class CoverageVerification(AbstractPreprocessor):
     """Ouputs docx files of court rulings with highlighted paragraphs of each section recognized aswell as the ruling outcome to data/verification folder. 
-    To run simply execute:
+    To run simply remove your desired spider from coverage_verification.txt and run:
     
-    python -m scrc.analyses.coverage_verification | python -m scrc.analyses.coverage_verification 1 (for rulings only)
-    
-    and make sure coverage_verification.txt exists."""
+    python -m scrc.analyses.coverage_verification | python -m scrc.analyses.coverage_verification 1 (for rulings only)"""
     
     def __init__(self, config: dict):
         super().__init__(config)
@@ -39,10 +37,6 @@ class CoverageVerification(AbstractPreprocessor):
 
     
     def start(self):
-        self.init_engine()
-        
-        
-    def init_engine(self):
         spider_list, message = self.compute_remaining_spiders(self.processed_file_path)
         self.logger.info(message)
         engine = self.get_engine(self.db_scrc)
@@ -52,7 +46,7 @@ class CoverageVerification(AbstractPreprocessor):
                 self.logger.info(self.logger_info['finish_spider'] + ' ' + spider)
                 self.mark_as_processed(self.processed_file_path, spider)
             self.logger.info(self.logger_info['finished'])
-
+        
                 
     def write_document(self, spider, conn: Connection):
         document = Document()
@@ -100,7 +94,7 @@ class CoverageVerification(AbstractPreprocessor):
                     ruling_text = ""
                     for ruling in rulings:
                         ruling_text += ruling.text + " "
-                    return {"wrapper": sections, "ruling": ruling.text}
+                    return {"wrapper": sections, "ruling": ruling_text}
           
             
     def get_sections(self, result: str, conn: Connection,):

--- a/scrc/preprocessors/extractors/judgment_extractor.py
+++ b/scrc/preprocessors/extractors/judgment_extractor.py
@@ -50,7 +50,7 @@ class JudgmentExtractor(AbstractExtractor):
         ruling_id = Section.RULINGS.value
         with self.get_engine(self.db_scrc).connect() as conn:
             total_judgments = conn.execute(get_total_judgments(spider, ruling_id)).fetchone()
-            coverage_result = conn.execute(get_judgment_query(spider, ruling_id)).fetchone()
+            coverage_result = conn.execute(get_judgment_query(spider)).fetchone()
             coverage =  round(coverage_result[0] / total_judgments[0]  * 100, 2)
             self.logger.info(f"{spider}: Found judgment outcome for {coverage}% of the rulings")
 

--- a/scrc/preprocessors/extractors/judgment_pattern_extractor.py
+++ b/scrc/preprocessors/extractors/judgment_pattern_extractor.py
@@ -5,6 +5,7 @@ import re
 import sys
 from typing import Any, TYPE_CHECKING
 from nltk.tokenize import sent_tokenize
+from scrc.utils.main_utils import clean_text, int_to_roman
 
 
 
@@ -19,10 +20,10 @@ from scrc.enums.section import Section
 from scrc.preprocessors.extractors.abstract_extractor import AbstractExtractor
 from scrc.utils.log_utils import get_logger
 from scrc.utils.main_utils import get_config
-from scrc.utils.sql_select_utils import get_judgment_query, get_total_judgments, join_decision_and_language_on_parameter, \
+from scrc.utils.sql_select_utils import get_judgment_query, get_total_decisions, get_total_judgments, join_decision_and_language_on_parameter, \
     join_file_on_decision, where_decisionid_in_list, where_string_spider
     
-from scrc.preprocessors.extractors.spider_specific.judgment_extracting_functions import prepare_judgment_markers
+from scrc.preprocessors.extractors.spider_specific.judgment_extracting_functions import get_nth_ruling, prepare_judgment_markers, search_rulings
 
 if TYPE_CHECKING:
     from pandas.core.frame import DataFrame
@@ -57,9 +58,10 @@ class JudgmentExtractor(AbstractExtractor):
         ruling_id = Section.RULINGS.value
         with self.get_engine(self.db_scrc).connect() as conn:
             total_judgments = conn.execute(get_total_judgments(spider, ruling_id)).fetchone()
-            coverage_result = conn.execute(get_judgment_query(spider, ruling_id)).fetchone()
+            coverage_result = conn.execute(get_judgment_query(spider)).fetchone()
+            total_cases = conn.execute(get_total_decisions(spider)).fetchone()
             coverage =  round(coverage_result[0] / total_judgments[0]  * 100, 2)
-            self.logger.info(f'{spider}: Found judgment outcome for {coverage}% of the rulings')
+            self.logger.info(f'{spider}:\n Found judgment outcome for {coverage}% of the rulings.\nJudgments found: {coverage_result[0]}.\nTotal non-empty rulings: {total_judgments[0]}\nTotal cases: {total_cases[0]}')
     
 
         
@@ -67,6 +69,7 @@ class JudgmentExtractor(AbstractExtractor):
         for spider in spider_list:
             if len(sys.argv) > 1:
                 self.get_coverage(spider)
+                self.mark_as_processed(self.processed_file_path, spider)
             else:
                 self.init_dict()
                 self.process_one_spider(engine, spider)
@@ -83,10 +86,11 @@ class JudgmentExtractor(AbstractExtractor):
     def process_one_spider(self, engine: Engine, spider: str):
         self.logger.info(self.logger_info["start_spider"] + " " + spider)
         dfs = self.select_df(self.get_engine(self.db_scrc), spider)  # Get the data needed for the extraction
-        for df in dfs:  
+        for idx, df in enumerate(dfs):  
             df = df.apply(self.process_one_df_row, axis="columns")
-            assigned_lists = self.assign_section()
-            self.df_to_csv(spider, assigned_lists)
+            self.logger.info(f"{idx + 1} df processed")
+        assigned_lists = self.assign_section()
+        self.df_to_csv(spider, assigned_lists)
         self.logger.info(f"{self.logger_info['finish_spider']} {spider}")
         
     
@@ -133,8 +137,7 @@ class JudgmentExtractor(AbstractExtractor):
         self.dict = {Language.DE: {}, Language.FR: {}, Language.IT: {}, Language.EN: {}, Language.UK: {}}
     
     def add_combinations(self, sentence, url, namespace):
-        # add url
-        for i in range(1, 4):
+        for i in range(1, 10):
             gram_list = self.create_ngrams(i, sentence)
             for gram in gram_list:
                 if gram in self.dict[namespace['language']]:
@@ -147,13 +150,22 @@ class JudgmentExtractor(AbstractExtractor):
         return [gram for gram in n_gram]
     
     def sentencize(self, data, namespace):
+        data = self.numbered_ruling(data)
         url = namespace['html_url']
         if url == '':
             url = namespace['pdf_url']
         sentence_list = sent_tokenize(data)
         for sentence in sentence_list:
             self.add_combinations(sentence.split(), url, namespace)
-        
+      
+    def numbered_ruling(self, data):
+        ruling = clean_text(data)
+        result = search_rulings(ruling, str(1), str(2))
+        if not result:
+            result = search_rulings(ruling, int_to_roman(1), int_to_roman(2))
+        if result:
+            return result.group(1)
+        return ruling
 
     def get_required_data(self, series: DataFrame) -> Any:
         """Returns the data required by the processing functions"""
@@ -162,10 +174,11 @@ class JudgmentExtractor(AbstractExtractor):
     def select_df(self, engine: str, spider: str) -> str:
         """Returns the `where` clause of the select statement for the entries to be processed by extractor"""
         only_given_decision_ids_string = f" AND {where_decisionid_in_list(self.decision_ids)}" if self.decision_ids is not None else ""
+        ruling_id = Section.RULINGS.value
         return self.select(engine,
                            f"section {join_decision_and_language_on_parameter('decision_id', 'section.decision_id')} {join_file_on_decision()}",
                            f"section.decision_id, section_text, '{spider}' as spider, iso_code as language, html_url",
-                           where=f"section.section_type_id = 5 AND section.decision_id IN {where_string_spider('decision_id', spider)} {only_given_decision_ids_string}",
+                           where=f"section.section_type_id = {ruling_id} AND section.decision_id IN {where_string_spider('decision_id', spider)} {only_given_decision_ids_string}",
                            chunksize=self.chunksize)
 
     def save_data_to_database(self, df: pd.DataFrame, engine: Engine):
@@ -173,83 +186,15 @@ class JudgmentExtractor(AbstractExtractor):
         
     def assign_section(self):
         sorted_lists = self.sort_dict()
-        all_judgment_markers = {
-            Language.DE: {
-                Judgment.APPROVAL: ['aufgehoben', 'aufzuheben', 'gutgeheissen', 'gutzuheissen', 'Gutheissung', 'schuldig', 'rechtmässig'],
-                Judgment.PARTIAL_APPROVAL: ['teilweise '],
-                Judgment.DISMISSAL: ['abgewiesen', 'abzuweisen', 'erstinstanzliche'],
-                Judgment.PARTIAL_DISMISSAL: ['abgewiesen, soweit',
-                                             'abzuweisen',
-                                             'abgewiesen',],
-                Judgment.INADMISSIBLE: ['Nichteintreten', 'nicht eingetreten', 'nicht einzutreten',
-                                        'wird keine Folge geleistet', 'nicht eingegangen',
-                                        'soweit darauf einzutreten ist', 'soweit auf sie einzutreten ist'],
-                Judgment.WRITE_OFF: ['abgeschrieben', 'abzuschreiben', 'gegenstandslos'],
-                Judgment.UNIFICATION: [
-                    "werden vereinigt", "werden gemeinsam beurteilt", "werden nicht vereinigt"]
-            },
-            Language.FR: {
-                Judgment.APPROVAL: ['admis', 'est annulé', 'Admet'],
-                Judgment.PARTIAL_APPROVAL: ['Admet partiellement',
-                                            'partiellement admis',
-                                            'admis dans la mesure où il est recevable',
-                                            'admis dans la mesure où ils sont recevables'
-                                            ],
-                Judgment.DISMISSAL: ['rejeté', 'Rejette', 'écarté'],
-                Judgment.PARTIAL_DISMISSAL: ['dans la mesure'],
-                Judgment.INADMISSIBLE: ['entre pas en matière', 'irrecevable', 'pas entré',
-                                        'pris en considération'],
-                Judgment.WRITE_OFF: ['retrait', 'radiée', 'sans objet', 'rayé', 'Raye'],
-                Judgment.UNIFICATION: [],
-    },
-    Language.IT: {
-        Judgment.APPROVAL: ['accolt',  # accolt o/i/a/e
-                            'annullat'],  # annullat o/i/a/e
-        Judgment.PARTIAL_APPROVAL: ['Nella misura in cui è ammissibile, il ricorso è parzialmente accolto',
-                                    'In parziale accoglimento del ricorso'],
-        Judgment.DISMISSAL: ['respint',  # respint o/i/a/e
-                             ],
-        Judgment.PARTIAL_DISMISSAL: ['Nella misura in cui è ammissibile, il ricorso è respinto',
-                                     'Nella misura in cui è ammissibile, il ricorso di diritto pubblico è respinto',
-                                     'Nella misura in cui è ammissibile, la domanda di revisione è respinta'],
-        Judgment.INADMISSIBLE: ['inammissibil',  # inamissibil o/i/a/e
-                                'irricevibil',  # irricevibil o/i/a/e
-                                ],
-        Judgment.WRITE_OFF: ['privo d\'oggetto', 'priva d\'oggetto', 'privo di oggetto', 'priva di oggetto',
-                             'è stralciata dai ruoli a seguito del ritiro del ricorso',
-                             'è stralciata dai ruoli in seguito al ritiro del ricorso',
-                             'stralciata dai ruoli',  # maybe too many mistakes
-                             'radiata dai ruoli',  # maybe too many mistakes
-                             ],
-        Judgment.UNIFICATION: ['sono congiunte'],    
-    },
-        Language.EN: {
-        Judgment.APPROVAL: [], 
-        Judgment.PARTIAL_APPROVAL: [],
-        Judgment.DISMISSAL: [],
-        Judgment.PARTIAL_DISMISSAL: [],
-        Judgment.INADMISSIBLE: [],
-        Judgment.WRITE_OFF: [],
-        Judgment.UNIFICATION: [],
-    }
-        }
         assigned_dict = {}
         for key in sorted_lists:
-            assigned_dict[key] = {'unknown': []}
-            language = {'language': key}
-            judgment_markers = prepare_judgment_markers(all_judgment_markers, language)
+            assigned_dict[key] = {}         
             for element in sorted_lists[key]:
+                type = f"{len(element[0])}_gram"
+                if(type not in assigned_dict[key]):
+                    assigned_dict[key][type] = []
                 string = ' '.join(element[0]) 
-                foundAssignment = False
-                for marker in judgment_markers: 
-                    if re.search(judgment_markers[marker], string):
-                        foundAssignment = True
-                        if marker in assigned_dict[key]:
-                            assigned_dict[key][marker].append(element)
-                        else:
-                            assigned_dict[key][marker] = [element]
-                if not foundAssignment:
-                    assigned_dict[key]['unknown'].append(element)
+                assigned_dict[key][type].append((element))
         return assigned_dict
         
         

--- a/scrc/preprocessors/extractors/pattern_extractor.py
+++ b/scrc/preprocessors/extractors/pattern_extractor.py
@@ -112,7 +112,7 @@ class PatternExtractor(AbstractExtractor):
             for lang_key in Language:
                 language_key = Language.get_id_value(lang_key.value)
                 if language_key != -1:
-                    total_result = conn.execute(get_total_decisions(spider, language_key)).fetchone()
+                    total_result = conn.execute(get_total_decisions(spider, True, language_key)).fetchone()
                     if total_result[0] != 0:
                         self.logger.info(f'Your coverage for {lang_key} of {spider} ({total_result[0]}):')
                         for section_key in Section:
@@ -122,7 +122,7 @@ class PatternExtractor(AbstractExtractor):
                                 if not coverage_result[0]:
                                     self.logger.info(f'No sections found for: {section_key}')
                                 else:
-                                    self.logger.info(f'{section_key} is {coverage}%')
+                                    self.logger.info(f'{section_key} is {coverage}%. Amount: {coverage_result[0]}')
     
     def start_spider_loop(self, spider_list: Set, engine: Engine):
         for spider in spider_list:
@@ -264,12 +264,12 @@ class PatternExtractor(AbstractExtractor):
                 foundAssigntment = False
                 for key in section_markers:
                     if re.search(section_markers[key], element):
-                        # if key == Section.RULINGS or len(element) < 400:
-                        row = df.loc[index]
-                        row['coverage'] = row['totalcount'] / count * 100
-                        dfs[key] = dfs[key].append(
-                            row, ignore_index=True)
-                        foundAssigntment = True
+                        if len(element) < 35:
+                            row = df.loc[index]
+                            row['coverage'] = row['totalcount'] / count * 100
+                            dfs[key] = dfs[key].append(
+                                row, ignore_index=True)
+                            foundAssigntment = True
                 if not foundAssigntment:
                     row = df.loc[index]
                     row['coverage'] = row['totalcount'] / count * 100

--- a/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/judgment_extracting_functions.py
@@ -61,7 +61,7 @@ Formelle Mitteilung:
 
 all_judgment_markers = {
     Language.DE: {
-        Judgment.APPROVAL: ['aufgehoben', 'aufzuheben', 'gutgeheissen', 'gutzuheissen', 'In Gutheissung', 'schuldig erklärt', 'rechtmässig'],
+        Judgment.APPROVAL: ['aufgehoben', 'aufzuheben', 'gutgeheissen', 'gutzuheissen', 'In Gutheissung'],
         Judgment.PARTIAL_APPROVAL: ['teilweise gutgeheissen', 'teilweise gutzuheissen',
                                     'In teilweiser Gutheissung'],
         Judgment.DISMISSAL: ['abgewiesen', 'abzuweisen', 'erstinstanzliche Urteil wird bestätigt', 'freigesprochen'],
@@ -79,7 +79,7 @@ all_judgment_markers = {
     Language.FR: {
         Judgment.APPROVAL: ['admis', 'est annulé', 'Admet', 'admet'],
         Judgment.PARTIAL_APPROVAL: ['Admet partiellement',
-                                    'partiellement admis',
+                                    'partiellement admis', 'admis partiellement'
                                     'admis dans la mesure où il est recevable',
                                     'admis dans la mesure où ils sont recevables'
                                     ],
@@ -136,7 +136,7 @@ def XX_SPIDER(rulings: str, namespace: dict) -> Optional[List[Judgment]]:
     judgments = get_judgments(rulings, namespace)
 
     judgments = verify_judgments(judgments, rulings, namespace)
-    
+
     return judgments
 
 def ZH_Baurekurs(rulings: str, namespace: dict) -> Optional[List[Judgment]]:
@@ -340,7 +340,6 @@ def get_judgments(rulings: str, namespace: dict) -> set:
     :return:            the set of judgment outcomes
     """
     judgments = set()
-
     judgment_markers = prepare_judgment_markers(
         all_judgment_markers, namespace)
 
@@ -350,6 +349,8 @@ def get_judgments(rulings: str, namespace: dict) -> set:
     if (re.search(pattern, rulings) or re.search(romanPattern, rulings)):
         judgments = numbered_rulings(
             judgments, rulings, namespace, judgment_markers)
+    else:
+        judgments = unnumbered_rulings(rulings, namespace)
     return judgments
 
 def verify_judgments(judgments, rulings, namespace):

--- a/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
+++ b/scrc/preprocessors/extractors/spider_specific/section_splitting_functions.py
@@ -74,16 +74,9 @@ def GE_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
                               r"Demnach wird verfügt", r"Dispositiv"],
             Section.FOOTER: [r'Rechtsmittellehre']
         },
-        Language.EN: {
-            Section.HEADER: [],
-            Section.FACTS: [],
-            Section.CONSIDERATIONS: [],
-            Section.RULINGS: [],
-            Section.FOOTER: []
-        },
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -107,7 +100,7 @@ def BE_Anwaltsaufsicht(decision: Union[bs4.BeautifulSoup, str], namespace: dict)
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -121,7 +114,7 @@ def BE_Weitere(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opti
         Language.DE: {
             Section.FACTS: [r'Sachverhalt'],
             Section.CONSIDERATIONS: [r'Erwägung', r'Erwägungen', r'erwogen', r'Ausgangslage$'],
-            Section.RULINGS: [r'entscheidet', r'wird erkannt', r'erkannt :', r'erkannt:', r'III. Entscheid', r'[1-9] Entscheid'],
+            Section.RULINGS: [r'entscheidet$', r'wird erkannt', r'erkannt :', r'erkannt:', r'III. Entscheid', r'[1-9] Entscheid'],
             Section.FOOTER: [r'^Rechtsmittelbelehrung']
         },
         Language.FR: {
@@ -132,7 +125,7 @@ def BE_Weitere(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opti
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -151,7 +144,7 @@ def AR_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -180,7 +173,7 @@ def BE_Steuerrekurs(decision: Union[bs4.BeautifulSoup, str], namespace: dict) ->
     }
     
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -198,7 +191,7 @@ def GL_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -216,7 +209,7 @@ def BL_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -234,7 +227,7 @@ def AG_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
         },
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -252,7 +245,7 @@ def AG_Weitere(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opti
         },
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -274,17 +267,9 @@ def CH_WEKO(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
             Section.RULINGS: [r'Dispositif$', r'DISPOSITIF$'],
             Section.FOOTER: [r'Voie de droit:?$']
         },
-        Language.EN: {
-            Section.HEADER: [],
-            Section.FACTS: [],
-            Section.CONSIDERATIONS: [],
-            Section.RULINGS: [],
-            Section.FOOTER: []
-        },
-        
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -309,15 +294,9 @@ def VD_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
                              r'La présidente:', r'Au nom du Tribunal administratif :', r'La présidente: Le greffier:',
                              r'Le président : Le greffier :']
         },
-        Language.EN: {
-            Section.FACTS: [],
-            Section.CONSIDERATIONS: [],
-            Section.RULINGS: [],
-            Section.FOOTER: []
-        }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -342,17 +321,10 @@ def TI_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
                               r'pronuncia:$', r'Per i quali motivi,', r'Per i quali motivi', r'^decide:$',
                               r'per questi motivi,', r'pronuncia: 1\.'],
             Section.FOOTER: [r'Per il Tribunale cantonale delle assicurazioni', r'Il presidente La segretaria', r'Per il Tribunale cantonale amministrativo', r'Per la seconda Camera civile del Tribunale d’appello', r'Il presidente La vicecancelliera']
-        },
-        Language.EN: {
-        },
-        Language.FR: {
-        },
-        Language.DE: {
-        }
-        
+        }, 
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -437,9 +409,8 @@ def NW_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
         }
     }
 
-    if namespace['language'] not in all_section_markers:
-        message = f"This function is only implemented for the languages {list(all_section_markers.keys())} so far."
-        raise ValueError(message)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
+
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -477,7 +448,7 @@ def BE_Verwaltungsgericht(decision: Union[bs4.BeautifulSoup, str], namespace: di
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -523,7 +494,7 @@ def GR_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
     paragraphs = get_pdf_paragraphs(decision)
@@ -549,7 +520,7 @@ def BS_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
                              r'AUFSICHTSKOMMISSION', r'APPELLATIONSGERICHT']
         }
     }
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -574,7 +545,7 @@ def VS_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
             Section.FOOTER: [r'no footer available']
         }
     }
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -599,7 +570,7 @@ def SZ_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
             Section.FOOTER: [r'^Namens', r'^Versand']
         }
     }
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -630,7 +601,7 @@ def SO_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -661,10 +632,7 @@ def CH_BGer(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
             Section.CONSIDERATIONS: [r'Erwägung:', r'[Ii]n Erwägung', r'Erwägungen:'],
             Section.RULINGS: [r'erkennt d[\w]{2} Präsident', r'Demnach (erkennt|beschliesst)', r'beschliesst.*:\s*$',
                               r'verfügt(\s[\wäöü]*){0,3}:\s*$', r'erk[ae]nnt(\s[\wäöü]*){0,3}:\s*$',
-                              r'Demnach verfügt[^e]'],
-            Section.FOOTER: [
-                r'^[\-\s\w\(]*,( den| vom)?\s\d?\d\.?\s?(?:Jan(?:uar)?|Feb(?:ruar)?|Mär(?:z)?|Apr(?:il)?|Mai|Jun(?:i)?|Jul(?:i)?|Aug(?:ust)?|Sep(?:tember)?|Okt(?:ober)?|Nov(?:ember)?|Dez(?:ember)?)\s\d{4}([\s]*$|.*(:|Im Namen))',
-                r'Im Namen des']
+                              r'Demnach verfügt[^e]', r'beschlossen:', r'erkennt das Eidg. Versicherungsgericht'],
         },
         Language.FR: {
             Section.TOPIC: [r'Objet'],
@@ -672,23 +640,18 @@ def CH_BGer(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
             Section.CONSIDERATIONS: [r'Considérant en (?:fait et en )?droit\s?:', r'(?:C|c)onsidérant(s?)\s?:',
                                      r'considère'],
             Section.RULINGS: [r'prononce\s?:', r'Par ces? motifs?\s?', r'ordonne\s?:'],
-            Section.FOOTER: [
-                r'\w*,\s(le\s?)?((\d?\d)|\d\s?(er|re|e)|premier|première|deuxième|troisième)\s?(?:janv|févr|mars|avr|mai|juin|juill|août|sept|oct|nov|déc).{0,10}\d?\d?\d\d\s?(.{0,5}[A-Z]{3}|(?!.{2})|[\.])',
-                r'Au nom de la Cour'
-            ]
         },
         Language.IT: {
             Section.TOPIC: [r'Oggetto'],
             Section.FACTS: [r'(F|f)att(i|o)\s?:'],
             Section.CONSIDERATIONS: [r'(C|c)onsiderando', r'(D|d)iritto\s?:', r'Visto:', r'Considerato'],
-            Section.RULINGS: [r'(P|p)er questi motivi'],
-            Section.FOOTER: [
+            Section.RULINGS: [r'(P|p)er questi motivi'],            Section.FOOTER: [
                 r'\w*,\s(il\s?)?((\d?\d)|\d\s?(°))\s?(?:gen(?:naio)?|feb(?:braio)?|mar(?:zo)?|apr(?:ile)?|mag(?:gio)|giu(?:gno)?|lug(?:lio)?|ago(?:sto)?|set(?:tembre)?|ott(?:obre)?|nov(?:embre)?|dic(?:embre)?)\s?\d?\d?\d\d\s?([A-Za-z\/]{0,7}):?\s*$'
             ]
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -762,7 +725,7 @@ def CH_BSTG(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -830,9 +793,13 @@ def valid_namespace(namespace: dict, all_section_markers):
     :param all_section_markers:     the section markers of a decision
     """
     if namespace['language'] not in all_section_markers:
-        message = f"This function is only implemented for the languages {list(all_section_markers.keys())} so far."
+        message = f"This function is only implemented for the languages {list(all_section_markers.keys())} so far. All paragraphs for {namespace['language']} will be added to the header."
         # Should exit exec here
-        raise ValueError(message)
+        all_section_markers[namespace['language']] = {}
+        get_logger(__name__).warning(message)
+        return all_section_markers
+    return all_section_markers
+        # raise ValueError(message)
 
 
 
@@ -854,14 +821,12 @@ def prepare_section_markers(all_section_markers, namespace: dict) -> Dict[Sectio
 def FR_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [],
             Section.FACTS: [r'Sachverhalt'],
             Section.CONSIDERATIONS: [r'Erwägungen', r' zieht in Erwägung,'],
             Section.RULINGS: [r'erkennt:$',r'erkennt der Hof:', r'entscheidet:$'],
             Section.FOOTER: [r'Gegen diesen Entscheid kann innerhalb', r'Dieses Urteil kann innert', r'Gegen die Festsetzung der Höhe der Verfahrenskosten', r'Gegen diesen Entscheid kann innert 30 Tagen', r'innert 30 Tagen']
         },
         Language.FR: {
-            Section.HEADER: [],
             Section.FACTS: [r'considérant en fait', r'^attendu$'],
             Section.CONSIDERATIONS: [r'considérant en fait et en droit', r'en droit$', r'^considérant$'],
             Section.RULINGS: [r'la Cour arrête', r'prononce:$', r'la Chambre arrête', r'arrête:?$'],
@@ -869,7 +834,7 @@ def FR_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
         },
     }
  
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -890,7 +855,7 @@ def OW_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
 
     custom_order = [Section.RULINGS, Section.FACTS, Section.CONSIDERATIONS]
     
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -921,17 +886,10 @@ def CH_EDOEB(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Option
             Section.RULINGS: [r'trasparenza formula le seguenti raccomandazioni'],
             Section.FOOTER: [r'Rechtsmittelbelehrung']
         },
-        Language.EN: {
-            Section.HEADER: [],
-            Section.FACTS: [],
-            Section.CONSIDERATIONS: [],
-            Section.RULINGS: [],
-            Section.FOOTER: []
-        },
     }
  
     
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -951,7 +909,7 @@ def SH_OG(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[
         },
     }
     
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -977,7 +935,7 @@ def VD_FindInfo(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
         },
     }
     
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -998,7 +956,7 @@ def LU_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
     
     custom_order = [Section.HEADER, Section.FACTS, Section.RULINGS, Section.CONSIDERATIONS, Section.FOOTER]
     
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -1018,7 +976,7 @@ def JU_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
         },
     }
     
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -1049,16 +1007,9 @@ def CH_BVGer(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Option
             Section.CONSIDERATIONS: [r'Ritenuto in fatto e considerato in diritto:', r'Diritto:', r'e considerato', r'Considerando in diritto'],
             Section.FOOTER: [r'Il presidente del collegio:', r'La presidente del collegio:', r'Rimedi di diritto', r'Data di spedizione:']
         },
-        Language.EN: {
-            Section.HEADER: [],
-            Section.FACTS: [],
-            Section.CONSIDERATIONS: [],
-            Section.RULINGS: [],
-            Section.FOOTER: []
-        },
     }
     
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -1085,7 +1036,7 @@ def GR_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
         },  
     }
     
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -1099,12 +1050,12 @@ def NE_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
             Section.HEADER: [],
             Section.FACTS: [r'Résumé'],
             Section.CONSIDERATIONS: [r'C O N S I D E R A N T', r'C O N S I D E RA N T', r'CO N S I D E R A N T', r'en droit', r'e n  d r o i t'],
-            Section.RULINGS: [r'Par ces motifs',r'Par cesmotifs'],
+            Section.RULINGS: [r'Par ces motifs',r'Par cesmotifs', r'Par ces motifs,'],
             Section.FOOTER: [r'Le greffier',r'AU NOM DU TRIBUNAL ADMINISTRATIF', r'^Neuchâtel, le ']
         }
     }
  
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -1117,7 +1068,6 @@ def NE_Omni(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optiona
 def SG_Publikationen(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional[Dict[Section, List[str]]]:
     all_section_markers = {
         Language.DE: {
-            Section.HEADER: [],
             Section.FACTS: [r'Sachverhalt', r'in Sachen', r'Aus dem Sachverhalt:', r'Zum Sachverhalt:', r'hat das Verwaltungsgericht festgestellt:', r'Das Verwaltungsgericht stellt fest:'],
             Section.CONSIDERATIONS: [r'Erwägungen', r'in Erwägung', r'Darüber zieht das Verwaltungsgericht in Erwägung:', r'Der Abteilungspräsident erwägt:'],
             Section.RULINGS: [r'zu Recht erkannt:',r'Demnach erkennt das Verwaltungsgericht zu Recht:', r'Demnach erkennt das Verwaltungsgericht auf dem Zirkulationsweg zu Recht:', r'Demnach hat das Verwaltungsgericht zu Recht erkannt:', r'Der Abteilungspräsident verfügt:', r'Der Präsident verfügt:'
@@ -1126,7 +1076,7 @@ def SG_Publikationen(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -
         }
     }
  
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -1144,7 +1094,7 @@ def SG_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
         }
     }
  
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -1197,7 +1147,7 @@ def update_section(current_section: Section, paragraph: str, section_markers, se
     :param sections:        if some sections are not present in the court, pass a list with the missing section excluded
     :return:                the updated section
     """
-    sections = sorted([Section.HEADER] + list(section_markers), key=lambda x: x.value)
+    sections = sorted([*set([Section.HEADER] + list(section_markers))], key=lambda x: x.value)
     paragraph = unicodedata.normalize(
         'NFC', paragraph)  # if we don't do this, we get weird matching behaviour
     if sections.index(current_section) == len(sections) - 1:
@@ -1231,17 +1181,10 @@ def CH_BGE(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional
             Section.CONSIDERATIONS: [r'Erwägungen'],
             Section.RULINGS: [r'Dispositiv'],
             Section.FOOTER: [r'^Rechtsmittelbelehrung']},
-        Language.EN: {
-            Section.HEADER: [],
-            Section.FACTS: [],
-            Section.CONSIDERATIONS: [],
-            Section.RULINGS: [],
-            Section.FOOTER: []
-        },
     }
  
     
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -1258,7 +1201,7 @@ def AI_Aktuell(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opti
         }
     }
  
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -1275,7 +1218,7 @@ def AI_Bericht(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opti
         }
     }
  
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -1293,7 +1236,7 @@ def AR_Gerichte(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Opt
         }
     }
  
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -1343,7 +1286,7 @@ def ZG_Verwaltungsgericht(decision: Union[bs4.BeautifulSoup, str], namespace: di
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -1383,7 +1326,7 @@ def ZH_Baurekurs(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Op
         },
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -1416,7 +1359,7 @@ def ZH_Obergericht(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> 
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -1446,7 +1389,7 @@ def ZH_Sozialversicherungsgericht(decision: Union[bs4.BeautifulSoup, str], names
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -1476,7 +1419,7 @@ def ZH_Steuerrekurs(decision: Union[bs4.BeautifulSoup, str], namespace: dict) ->
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -1520,7 +1463,7 @@ def ZH_Verwaltungsgericht(decision: Union[bs4.BeautifulSoup, str], namespace: di
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -1584,7 +1527,7 @@ def BE_BVD(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Optional
         },
     }
     
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
     
@@ -1653,7 +1596,7 @@ def BE_ZivilStraf(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> O
         }
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 
@@ -1699,7 +1642,7 @@ def CH_BPatG(decision: Union[bs4.BeautifulSoup, str], namespace: dict) -> Option
             
     }
 
-    valid_namespace(namespace, all_section_markers)
+    all_section_markers = valid_namespace(namespace, all_section_markers)
 
     section_markers = prepare_section_markers(all_section_markers, namespace)
 

--- a/scrc/utils/sql_select_utils.py
+++ b/scrc/utils/sql_select_utils.py
@@ -36,36 +36,31 @@ def coverage_query(spider: str, section_type: int, language: int):
             f"AND section_text != '{{}}'"
             f"AND section_text != '' ")
 
-def get_total_decisions(spider: str, language: int):
-    return (f"SELECT count(*) FROM decision "
+def get_total_decisions(spider: str, filter_by_language = False, language = 0):
+    query = (f"SELECT count(*) FROM decision "
         f"LEFT JOIN language ON decision.language_id = language.language_id "
         f"LEFT JOIN chamber ON chamber.chamber_id = decision.chamber_id "
         f"LEFT JOIN spider ON spider.spider_id = chamber.spider_id "
-        f"WHERE spider.name = '{spider}' "
-        f"AND language.language_id = {language} ")
+        f"WHERE spider.name = '{spider}' ")
+    if filter_by_language:
+        query += f"AND language.language_id = {language} "
+    return query
     
-def get_judgment_query(spider, ruling_id):
-    return (f"SELECT count(*) FROM section s "
-            f"LEFT JOIN decision ON decision.decision_id = s.decision_id "
-            f"LEFT JOIN judgment_map j "
-            f"ON j.decision_id = decision.decision_id "
-            f"LEFT JOIN chamber ON chamber.chamber_id = decision.chamber_id "
-            f"LEFT JOIN spider ON spider.spider_id = chamber.spider_id "
-            f"WHERE spider.name = '{spider}' "
-            f"AND section_text != '{{}}' "
-            f"AND section_text != '' "
-            f"AND s.section_type_id = {ruling_id} "
-            f"AND j.judgment_id IS NOT NULL")
+def get_judgment_query(spider):
+    return (f"SELECT count(DISTINCT d.decision_id) FROM decision d "
+            f"LEFT JOIN chamber c ON c.chamber_id = d.chamber_id "
+            f"LEFT JOIN spider sp ON sp.spider_id = c.spider_id "
+            f"LEFT JOIN judgment_map j ON j.decision_id = d.decision_id "
+            f"WHERE judgment_id IS NOT NULL "
+            f"AND sp.name = '{spider}' ")
 
 def get_total_judgments(spider, ruling_id):
-    return (f"SELECT count(*) FROM section s "
-        f"LEFT JOIN decision ON decision.decision_id = s.decision_id "
-        f"LEFT JOIN judgment_map j "
-        f"ON j.decision_id = decision.decision_id "
-        f"LEFT JOIN chamber ON chamber.chamber_id = decision.chamber_id "
-        f"LEFT JOIN spider ON spider.spider_id = chamber.spider_id "
-        f"WHERE spider.name = '{spider}' "
-        f"AND section_text != '{{}}' "
+    return (f"SELECT count(*) FROM decision d "
+        f"LEFT JOIN section s ON d.decision_id = s.decision_id "
+        f"LEFT JOIN section_type t ON t.section_type_id = s.section_type_id "
+        f"LEFT JOIN chamber c ON c.chamber_id = d.chamber_id "
+        f"LEFT JOIN spider sp ON sp.spider_id = c.spider_id "
+        f"WHERE sp.name = '{spider}' "
         f"AND section_text != '' "
         f"AND s.section_type_id = {ruling_id} ")
 


### PR DESCRIPTION
- Coverage verification now only selects random decisions with existing outcomes.
- Section_splitting function -> No need to implement all languages for a court anymore. Valid namespace makes sure that the program doesn't crash if a decision with a non-existing language such as EN is trying to get processed.
-  corrected multiple sql queries. Amount of judgments found was counted multiple times for decisions with multiple judgments. 
-  adapted judgment_pattern_extractor to find judgment outcome patterns more precisely by considering only the context between the numbers for numbered rulings

